### PR TITLE
#10 & #9 - share a file and/or folder with other person by email +  clone an existing file enhancement

### DIFF
--- a/force-app/main/default/google-drive/GoogleConstants.cls
+++ b/force-app/main/default/google-drive/GoogleConstants.cls
@@ -2,6 +2,8 @@ public class GoogleConstants {
     public static final String SEARCH_DRIVES_ENDPOINT = 'https://www.googleapis.com/drive/v3/drives';
     public static final String SEARCH_FILES_ENDPOINT = 'https://www.googleapis.com/drive/v3/files';
     public static final String UPLOAD_FILES_ENDPOINT = 'https://www.googleapis.com/upload/drive/v3/files';
+    public static final String CLONE_FILE_ENDPOINT = 'https://www.googleapis.com/drive/v3/files/{0}/copy';
+    public static final String NEW_PERMISSION_FILE_ENDPOINT = 'https://www.googleapis.com/drive/v3/files/{0}/permissions';
 
     public static final Integer HTTP_SUCCESS_STATUS_CODE = 200;
     public static final Integer HTTP_UNAUTHORIZED_STATUS_CODE = 401;

--- a/force-app/main/default/google-drive/classes/GoogleDrive.cls
+++ b/force-app/main/default/google-drive/classes/GoogleDrive.cls
@@ -88,5 +88,18 @@ public without sharing class GoogleDrive {
                 'POST'
             );
         }
+
+        public GoogleCloneFileBuilder clone(String fileId) {
+            return new GoogleCloneFileBuilder(
+                googleDriveInstance,
+                fileId,
+                GoogleConstants.CLONE_FILE_ENDPOINT,
+                'POST'
+            );
+        }
+
+        public GooglePermissionFileFactory permission() {
+            return new GooglePermissionFileFactory(googleDriveInstance);
+        }
     }
 }

--- a/force-app/main/default/google-drive/classes/GoogleDriveTest.cls
+++ b/force-app/main/default/google-drive/classes/GoogleDriveTest.cls
@@ -230,6 +230,66 @@ private class GoogleDriveTest {
         Test.stopTest();
     }
 
+    @isTest
+    private static void testClone() {
+        String testFileId = '1lhu72ZrlfzRljhP4t12RE5GDGa8n7Yv8LHWy20_QBqw';
+        String successFileCloned = '{"kind": "drive#file","id": "1lhu72ZrlfzRljhP4t12RE5GDGa8n7Yv8LHWy20_QBqw","name": "CopiedDocument"}';
+        GoogleDriveHttpMockGenerator testCalloutMock = new GoogleDriveHttpMockGenerator(
+            buildFileDependentEndpoint(GoogleConstants.CLONE_FILE_ENDPOINT, testFileId),
+            GoogleConstants.HTTP_SUCCESS_STATUS_CODE,
+            successFileCloned
+        );
+
+        Test.startTest();
+        Test.setMock(HttpCalloutMock.class, testCalloutMock);
+        buildGoogleDriveInfo();
+
+        GoogleDrive testGoogleDrive = new GoogleDrive(testCredentials, userAgentName);
+        GoogleFileEntity result = testGoogleDrive.files().clone(testFileId)
+            .setFields('id, name')
+            .setFileName('CopiedDocument')
+            .setMimeType('application/vnd.google-apps.document')
+            .setParentFolders(new List<String>{'1lhu72ZrlfzRljhP4t12RE5GDGa8n7Yv8LHWy20_QBqw'})
+            .execute();
+
+        // Fields that are specified in "setFields()" will be received 
+        // in response to the cloning of the document
+        Assert.isNotNull(result.id);
+        Assert.isNotNull(result.name);
+        Test.stopTest();
+    }
+
+    @isTest
+    private static void testPermissionFileCreate() {
+        String testFileId = '1lhu72ZrlfzRljhP4t12RE5GDGa8n7Yv8LHWy20_QBqw';
+        String successFilePermissionCreated = '{"kind": "drive#permission","id": "1lhu72ZrlfzRljhP4t12RE5GDGa8n7Yv8LHWy20_QBqw","type": "user","emailAddress": "test@gmail.com","role": "reader","domain": "","allowFileDiscovery": false,"displayName": "Example User"}';
+        GoogleDriveHttpMockGenerator testCalloutMock = new GoogleDriveHttpMockGenerator(
+            buildFileDependentEndpoint(GoogleConstants.NEW_PERMISSION_FILE_ENDPOINT, testFileId),
+            GoogleConstants.HTTP_SUCCESS_STATUS_CODE,
+            successFilePermissionCreated
+        );
+
+        Test.startTest();
+        Test.setMock(HttpCalloutMock.class, testCalloutMock);
+        buildGoogleDriveInfo();
+
+        GoogleDrive testGoogleDrive = new GoogleDrive(testCredentials, userAgentName);
+        GooglePermissionEntity result = testGoogleDrive.files().permission().create(testFileId)
+            .setSendNotificationEmail(true)
+            .setTransferOwnership(false)
+            .setPrincipalType('user')
+            .setPrincipalRole('reader')
+            .setPrincipalEmailAddress('test@gmail.com')
+            .execute();
+
+        Assert.isNotNull(result.id);
+        Test.stopTest();
+    }
+
+    private static String buildFileDependentEndpoint(String baseEndpoint, String fileId) {
+        return String.format(baseEndpoint, new List<String>{fileId});
+    }
+
     private static void buildGoogleDriveInfo() {
         userAgentName = 'Google Drive/v3 test';
         testCredentials = new GoogleCredential();

--- a/force-app/main/default/google-drive/classes/builders/GoogleCloneFileBuilder.cls
+++ b/force-app/main/default/google-drive/classes/builders/GoogleCloneFileBuilder.cls
@@ -1,0 +1,78 @@
+public class GoogleCloneFileBuilder implements GoogleFileCreator {
+    private GoogleRequestBuilder requestGoogleBuilder;
+
+    private String metadataFileName;
+    private String metadataMimeType;
+    private List<String> metadataParentFolders;
+
+    public GoogleCloneFileBuilder(GoogleDrive googleDriveInstance, String fileId, String endpoint, String method) {
+        this.requestGoogleBuilder = new GoogleRequestBuilder(googleDriveInstance);
+        this.metadataParentFolders = new List<String>();
+
+        this.requestGoogleBuilder.setEndpoint(this.buildCloneFileEndpoint(endpoint, fileId));
+        this.requestGoogleBuilder.setMethod(method);
+        this.requestGoogleBuilder.setHeader('User-Agent', googleDriveInstance.userAgentName);
+        this.requestGoogleBuilder.setHeader('Content-Type', 'application/json');
+    }
+
+    public GoogleCloneFileBuilder setFields(String fields) {
+        this.requestGoogleBuilder.setParameter('fields', fields);
+        return this;
+    }
+
+    public GoogleCloneFileBuilder setFileName(String fileName) {
+        this.metadataFileName = fileName;
+        return this;
+    }
+
+    public GoogleCloneFileBuilder setMimeType(String mimeType) {
+        this.metadataMimeType = mimeType;
+        return this;
+    }
+
+    public GoogleCloneFileBuilder setParentFolders(List<String> folderIds) {
+        this.metadataParentFolders = folderIds;
+        return this;
+    }
+
+    public GoogleFileEntity execute() {
+        String cloneBody = this.buildCloningRequestBody();
+        this.requestGoogleBuilder.setHeader('Content-Length', cloneBody.length());
+        this.requestGoogleBuilder.setBody(cloneBody);
+
+        HTTPResponse cloneResponse = this.requestGoogleBuilder.send();
+        return this.retrieveRequestUploadWrapper(cloneResponse);
+    }
+
+    private GoogleFileEntity retrieveRequestUploadWrapper(HTTPResponse cloneResponse) {
+        if (cloneResponse.getStatusCode() == GoogleConstants.HTTP_SUCCESS_STATUS_CODE) {
+            return (GoogleFileEntity) JSON.deserialize(cloneResponse.getBody(), GoogleFileEntity.class);
+        } else {
+            throw new CalloutException(cloneResponse.getBody());
+        }
+    }
+
+    private String buildCloneFileEndpoint(String baseEndpoint, String fileId) {
+        return String.format(baseEndpoint, new List<String>{fileId});
+    }
+
+    private String buildCloningRequestBody() {
+        Map<String, Object> fileMetadata = new Map<String, Object>();
+        this.addPairIfNotEmpty(fileMetadata, 'name', this.metadataFileName);
+        this.addPairIfNotEmpty(fileMetadata, 'mimeType', this.metadataMimeType);
+        this.addPairIfNotEmpty(fileMetadata, 'parents', this.metadataParentFolders);
+        return fileMetadata.isEmpty() ? '' : JSON.serialize(fileMetadata, true);
+    }
+
+    private void addPairIfNotEmpty(Map<String, Object> originMap, String key, String value) {
+        if (String.isNotBlank(value)) {
+            originMap.put(key, value);
+        }
+    }
+
+    private void addPairIfNotEmpty(Map<String, Object> originMap, String key, List<String> values) {
+        if (values != null && !values.isEmpty()) {
+            originMap.put(key, values);
+        }
+    }
+}

--- a/force-app/main/default/google-drive/classes/builders/GoogleCloneFileBuilder.cls-meta.xml
+++ b/force-app/main/default/google-drive/classes/builders/GoogleCloneFileBuilder.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/google-drive/classes/builders/GoogleCreatePermissionFileBuilder.cls
+++ b/force-app/main/default/google-drive/classes/builders/GoogleCreatePermissionFileBuilder.cls
@@ -1,0 +1,60 @@
+public class GoogleCreatePermissionFileBuilder {
+    private GoogleRequestBuilder requestGoogleBuilder;
+    private Map<String, String> newPermission;
+
+    public GoogleCreatePermissionFileBuilder(GoogleDrive googleDriveInstance, String endpoint, String method) {
+        this.requestGoogleBuilder = new GoogleRequestBuilder(googleDriveInstance);
+        this.newPermission = new Map<String, String>();
+
+        this.requestGoogleBuilder.setEndpoint(endpoint);
+        this.requestGoogleBuilder.setMethod(method);
+        this.requestGoogleBuilder.setHeader('User-Agent', googleDriveInstance.userAgentName);
+        this.requestGoogleBuilder.setHeader('Content-Type', 'application/json');
+    }
+
+    public GoogleCreatePermissionFileBuilder setSendNotificationEmail(Boolean isSendEmail) {
+        this.requestGoogleBuilder.setParameter('sendNotificationEmail', isSendEmail);
+        return this;
+    }
+
+    public GoogleCreatePermissionFileBuilder setTransferOwnership(Boolean isTransferOwnership) {
+        this.requestGoogleBuilder.setParameter('transferOwnership', isTransferOwnership);
+        return this;
+    }
+
+    public GoogleCreatePermissionFileBuilder setPrincipalType(String type) {
+        this.newPermission.put('type', type);
+        return this;
+    }
+
+    public GoogleCreatePermissionFileBuilder setPrincipalRole(String role) {
+        this.newPermission.put('role', role);
+        return this;
+    }
+
+    public GoogleCreatePermissionFileBuilder setPrincipalEmailAddress(String emailAddress) {
+        this.newPermission.put('emailAddress', emailAddress);
+        return this;
+    }
+
+    public GooglePermissionEntity execute() {
+        String permissionBody = this.buildPermissionFileRequestBody();
+        this.requestGoogleBuilder.setHeader('Content-Length', permissionBody.length());
+        this.requestGoogleBuilder.setBody(permissionBody);
+
+        HTTPResponse permissionResponse = this.requestGoogleBuilder.send();
+        return this.retrieveRequestUploadWrapper(permissionResponse);
+    }
+
+    private GooglePermissionEntity retrieveRequestUploadWrapper(HTTPResponse permissionResponse) {
+        if (permissionResponse.getStatusCode() == GoogleConstants.HTTP_SUCCESS_STATUS_CODE) {
+            return (GooglePermissionEntity) JSON.deserialize(permissionResponse.getBody(), GooglePermissionEntity.class);
+        } else {
+            throw new CalloutException(permissionResponse.getBody());
+        }
+    }
+
+    private String buildPermissionFileRequestBody() {
+        return this.newPermission.isEmpty() ? '' : JSON.serialize(this.newPermission, true);
+    }
+}

--- a/force-app/main/default/google-drive/classes/builders/GoogleCreatePermissionFileBuilder.cls-meta.xml
+++ b/force-app/main/default/google-drive/classes/builders/GoogleCreatePermissionFileBuilder.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/google-drive/classes/builders/GoogleMultipartFileBuilder.cls
+++ b/force-app/main/default/google-drive/classes/builders/GoogleMultipartFileBuilder.cls
@@ -1,4 +1,4 @@
-public class GoogleMultipartFileBuilder {
+public class GoogleMultipartFileBuilder implements GoogleFileCreator {
     private GoogleRequestBuilder requestGoogleBuilder;
 
     private String metadataFileName;
@@ -66,15 +66,15 @@ public class GoogleMultipartFileBuilder {
     public GoogleFileEntity execute() {
         this.requestGoogleBuilder.setBody(this.buildMultipartRequestBody());
 
-        HTTPResponse searchResponse = this.requestGoogleBuilder.send();
-        return this.retrieveRequestUploadWrapper(searchResponse);
+        HTTPResponse uploadResponse = this.requestGoogleBuilder.send();
+        return this.retrieveRequestUploadWrapper(uploadResponse);
     }
 
-    private GoogleFileEntity retrieveRequestUploadWrapper(HTTPResponse searchResponse) {
-        if (searchResponse.getStatusCode() == GoogleConstants.HTTP_SUCCESS_STATUS_CODE) {
-            return (GoogleFileEntity) JSON.deserialize(searchResponse.getBody(), GoogleFileEntity.class);
+    private GoogleFileEntity retrieveRequestUploadWrapper(HTTPResponse uploadResponse) {
+        if (uploadResponse.getStatusCode() == GoogleConstants.HTTP_SUCCESS_STATUS_CODE) {
+            return (GoogleFileEntity) JSON.deserialize(uploadResponse.getBody(), GoogleFileEntity.class);
         } else {
-            throw new CalloutException(searchResponse.getBody());
+            throw new CalloutException(uploadResponse.getBody());
         }
     }
 

--- a/force-app/main/default/google-drive/classes/builders/GoogleSimpleFileBuilder.cls
+++ b/force-app/main/default/google-drive/classes/builders/GoogleSimpleFileBuilder.cls
@@ -1,4 +1,4 @@
-public class GoogleSimpleFileBuilder {
+public class GoogleSimpleFileBuilder implements GoogleFileCreator {
     private GoogleRequestBuilder requestGoogleBuilder;
 
     public GoogleSimpleFileBuilder(GoogleDrive googleDriveInstance, String endpoint, String method) {
@@ -35,15 +35,15 @@ public class GoogleSimpleFileBuilder {
     }
 
     public GoogleFileEntity execute() {
-        HTTPResponse searchResponse = this.requestGoogleBuilder.send();
-        return this.retrieveRequestUploadWrapper(searchResponse);
+        HTTPResponse uploadResponse = this.requestGoogleBuilder.send();
+        return this.retrieveRequestUploadWrapper(uploadResponse);
     }
 
-    private GoogleFileEntity retrieveRequestUploadWrapper(HTTPResponse searchResponse) {
-        if (searchResponse.getStatusCode() == GoogleConstants.HTTP_SUCCESS_STATUS_CODE) {
-            return (GoogleFileEntity) JSON.deserialize(searchResponse.getBody(), GoogleFileEntity.class);
+    private GoogleFileEntity retrieveRequestUploadWrapper(HTTPResponse uploadResponse) {
+        if (uploadResponse.getStatusCode() == GoogleConstants.HTTP_SUCCESS_STATUS_CODE) {
+            return (GoogleFileEntity) JSON.deserialize(uploadResponse.getBody(), GoogleFileEntity.class);
         } else {
-            throw new CalloutException(searchResponse.getBody());
+            throw new CalloutException(uploadResponse.getBody());
         }
     }
 }

--- a/force-app/main/default/google-drive/classes/entities/GooglePermissionEntity.cls
+++ b/force-app/main/default/google-drive/classes/entities/GooglePermissionEntity.cls
@@ -1,0 +1,31 @@
+public class GooglePermissionEntity {
+    public String id;
+    public String displayName;
+    public String type;
+    public String kind;
+    public List<PermissionDetail> permissionDetails;
+    public String photoLink;
+    public String emailAddress;
+    public String role;
+    public Boolean allowFileDiscovery;
+    public String domain;
+    public String expirationTime;
+    public List<TeamDrivePermissionDetail> teamDrivePermissionDetails;
+    public Boolean deleted;
+    public String view;
+    public Boolean pendingOwner;
+
+    public class PermissionDetail {
+        public String permissionType;
+        public String inheritedFrom;
+        public String role;
+        public Boolean inherited;
+    }
+
+    public class TeamDrivePermissionDetail {
+        public String teamDrivePermissionType;
+        public String inheritedFrom;
+        public String role;
+        public Boolean inherited;
+    }
+}

--- a/force-app/main/default/google-drive/classes/entities/GooglePermissionEntity.cls-meta.xml
+++ b/force-app/main/default/google-drive/classes/entities/GooglePermissionEntity.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/google-drive/classes/factories/GooglePermissionFileFactory.cls
+++ b/force-app/main/default/google-drive/classes/factories/GooglePermissionFileFactory.cls
@@ -1,0 +1,19 @@
+public class GooglePermissionFileFactory {
+    private GoogleDrive googleDriveInstance;
+
+    public GooglePermissionFileFactory(GoogleDrive googleDriveInstance) {
+        this.googleDriveInstance = googleDriveInstance;
+    }
+
+    public GoogleCreatePermissionFileBuilder create(String fileId) {
+        return new GoogleCreatePermissionFileBuilder(
+            this.googleDriveInstance,
+            this.buildCreatePermissionFileEndpoint(fileId),
+            'POST'
+        );
+    }
+
+    private String buildCreatePermissionFileEndpoint(String fileId) {
+        return String.format(GoogleConstants.NEW_PERMISSION_FILE_ENDPOINT, new List<String>{fileId});
+    }
+}

--- a/force-app/main/default/google-drive/classes/factories/GooglePermissionFileFactory.cls-meta.xml
+++ b/force-app/main/default/google-drive/classes/factories/GooglePermissionFileFactory.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/google-drive/interfaces/GoogleFileCreator.cls
+++ b/force-app/main/default/google-drive/interfaces/GoogleFileCreator.cls
@@ -1,9 +1,7 @@
 /** 
- * 
+ * The GoogleFileCreator classifies builders that create files on Google Drive,
+ * including those that work with files and have a return type of an instance of that file.
 */
 public interface GoogleFileCreator {
-    /**
-     * 
-    */
     GoogleFileEntity execute();
 }


### PR DESCRIPTION
Implemented [cloning of a file (including a folder)](#9), including options to change the type and folder of the cloned file. In addition, a new factory has been added for [working with permissions](#10), namely for sharing a file with a person by email, although following the original conditions, implementations of sharing a file for a group of people at the same time are not possible due to the limitations of the Google Drive API.