### PR TITLE
#18: Creating a method to export/download documents from Google Drive

### DIFF
--- a/force-app/main/default/google-drive/GoogleConstants.cls
+++ b/force-app/main/default/google-drive/GoogleConstants.cls
@@ -4,6 +4,8 @@ public class GoogleConstants {
     public static final String UPLOAD_FILES_ENDPOINT = 'https://www.googleapis.com/upload/drive/v3/files';
     public static final String CLONE_FILE_ENDPOINT = 'https://www.googleapis.com/drive/v3/files/{0}/copy';
     public static final String NEW_PERMISSION_FILE_ENDPOINT = 'https://www.googleapis.com/drive/v3/files/{0}/permissions';
+    public static final String EXPORT_FILE_ENDPOINT = 'https://www.googleapis.com/drive/v3/files/{0}/export';
+    public static final String GET_FILE_ENDPOINT = 'https://www.googleapis.com/drive/v3/files/{0}';
 
     public static final Integer HTTP_SUCCESS_STATUS_CODE = 200;
     public static final Integer HTTP_UNAUTHORIZED_STATUS_CODE = 401;

--- a/force-app/main/default/google-drive/classes/GoogleDrive.cls
+++ b/force-app/main/default/google-drive/classes/GoogleDrive.cls
@@ -89,6 +89,10 @@ public without sharing class GoogleDrive {
             );
         }
 
+        public GoogleRetrieveFileFactory retrieve() {
+            return new GoogleRetrieveFileFactory(googleDriveInstance);
+        } 
+
         public GoogleCloneFileBuilder clone(String fileId) {
             return new GoogleCloneFileBuilder(
                 googleDriveInstance,

--- a/force-app/main/default/google-drive/classes/GoogleDriveTest.cls
+++ b/force-app/main/default/google-drive/classes/GoogleDriveTest.cls
@@ -286,6 +286,76 @@ private class GoogleDriveTest {
         Test.stopTest();
     }
 
+    @isTest
+    private static void testRetrieveFileByDownloadMetadata() {
+        String testFileId = '1lhu72ZrlfzRljhP4t12RE5GDGa8n7Yv8LHWy20_QBqw';
+        String successFileDownloaded = '{"kind": "drive#file","id": "1lhu72ZrlfzRljhP4t12RE5GDGa8n7Yv8LHWy20_QBqw","name": "filename","mimeType": "application/pdf"}';
+        GoogleDriveHttpMockGenerator testCalloutMock = new GoogleDriveHttpMockGenerator(
+            buildFileDependentEndpoint(GoogleConstants.GET_FILE_ENDPOINT, testFileId),
+            GoogleConstants.HTTP_SUCCESS_STATUS_CODE,
+            successFileDownloaded
+        );
+
+        Test.startTest();
+        Test.setMock(HttpCalloutMock.class, testCalloutMock);
+        buildGoogleDriveInfo();
+
+        GoogleDrive testGoogleDrive = new GoogleDrive(testCredentials, userAgentName);
+        GoogleFileEntity result = testGoogleDrive.files().retrieve().download(testFileId)
+            .setFileDownloadType(GoogleDownloadFileBuilder.DownloadType.METADATA)
+            .setSearchOnAllDrives(false)
+            .execute();
+
+        Assert.isNotNull(result.id);
+        Test.stopTest();
+    }
+
+    @isTest
+    private static void testRetrieveFileByDownloadContent() {
+        String testFileId = '1lhu72ZrlfzRljhP4t12RE5GDGa8n7Yv8LHWy20_QBqw';
+        String successFileDownloaded = 'JVBERi0xLjUKJdP0zOEKNSAwIG9iaiA8PAovQ3JlYXRvciAoQWRvYmUgUERGIGxpYn';
+        GoogleDriveHttpMockGenerator testCalloutMock = new GoogleDriveHttpMockGenerator(
+            buildFileDependentEndpoint(GoogleConstants.GET_FILE_ENDPOINT, testFileId),
+            GoogleConstants.HTTP_SUCCESS_STATUS_CODE,
+            successFileDownloaded
+        );
+
+        Test.startTest();
+        Test.setMock(HttpCalloutMock.class, testCalloutMock);
+        buildGoogleDriveInfo();
+
+        GoogleDrive testGoogleDrive = new GoogleDrive(testCredentials, userAgentName);
+        GoogleFileEntity result = testGoogleDrive.files().retrieve().download(testFileId)
+            .setFileDownloadType(GoogleDownloadFileBuilder.DownloadType.CONTENT)
+            .execute();
+
+        Assert.isNotNull(result.body);
+        Test.stopTest();
+    }
+
+    @isTest
+    private static void testRetrieveFileByExport() {
+        String testFileId = '1lhu72ZrlfzRljhP4t12RE5GDGa8n7Yv8LHWy20_QBqw';
+        String successFileExported = '{"body": {"content": [{"endIndex": 650, "paragraph": {"elements": [{"endIndex": 650, "startIndex": 590, "textRun": {"content": "And this is a paragraph that follows the level two heading.\n", "textStyle": {}}}], "paragraphStyle": {"direction": "LEFT_TO_RIGHT", "namedStyleType": "NORMAL_TEXT"}}, "startIndex": 590}]}, "documentId": "1lhu72ZrlfzRljhP4t12RE5GDGa8n7Yv8LHWy20_QBqw", "documentStyle": {}, "lists": {}, "namedStyles": {"styles": []}, "revisionId": "np_INheZiecEMA", "suggestionsViewMode": "SUGGESTIONS_INLINE", "title": "Test mule"}';
+        GoogleDriveHttpMockGenerator testCalloutMock = new GoogleDriveHttpMockGenerator(
+            buildFileDependentEndpoint(GoogleConstants.EXPORT_FILE_ENDPOINT, testFileId),
+            GoogleConstants.HTTP_SUCCESS_STATUS_CODE,
+            successFileExported
+        );
+
+        Test.startTest();
+        Test.setMock(HttpCalloutMock.class, testCalloutMock);
+        buildGoogleDriveInfo();
+
+        GoogleDrive testGoogleDrive = new GoogleDrive(testCredentials, userAgentName);
+        GoogleFileEntity result = testGoogleDrive.files().retrieve().export(testFileId)
+            .setMimeType('text/plain')
+            .execute();
+
+        Assert.isNotNull(result.body);
+        Test.stopTest();
+    }
+
     private static String buildFileDependentEndpoint(String baseEndpoint, String fileId) {
         return String.format(baseEndpoint, new List<String>{fileId});
     }

--- a/force-app/main/default/google-drive/classes/builders/GoogleCloneFileBuilder.cls
+++ b/force-app/main/default/google-drive/classes/builders/GoogleCloneFileBuilder.cls
@@ -41,10 +41,10 @@ public class GoogleCloneFileBuilder implements GoogleFileCreator {
         this.requestGoogleBuilder.setBody(cloneBody);
 
         HTTPResponse cloneResponse = this.requestGoogleBuilder.send();
-        return this.retrieveRequestUploadWrapper(cloneResponse);
+        return this.retrieveRequestClonedWrapper(cloneResponse);
     }
 
-    private GoogleFileEntity retrieveRequestUploadWrapper(HTTPResponse cloneResponse) {
+    private GoogleFileEntity retrieveRequestClonedWrapper(HTTPResponse cloneResponse) {
         if (cloneResponse.getStatusCode() == GoogleConstants.HTTP_SUCCESS_STATUS_CODE) {
             return (GoogleFileEntity) JSON.deserialize(cloneResponse.getBody(), GoogleFileEntity.class);
         } else {

--- a/force-app/main/default/google-drive/classes/builders/GoogleCreatePermissionFileBuilder.cls
+++ b/force-app/main/default/google-drive/classes/builders/GoogleCreatePermissionFileBuilder.cls
@@ -43,10 +43,10 @@ public class GoogleCreatePermissionFileBuilder {
         this.requestGoogleBuilder.setBody(permissionBody);
 
         HTTPResponse permissionResponse = this.requestGoogleBuilder.send();
-        return this.retrieveRequestUploadWrapper(permissionResponse);
+        return this.retrieveRequestPermissionWrapper(permissionResponse);
     }
 
-    private GooglePermissionEntity retrieveRequestUploadWrapper(HTTPResponse permissionResponse) {
+    private GooglePermissionEntity retrieveRequestPermissionWrapper(HTTPResponse permissionResponse) {
         if (permissionResponse.getStatusCode() == GoogleConstants.HTTP_SUCCESS_STATUS_CODE) {
             return (GooglePermissionEntity) JSON.deserialize(permissionResponse.getBody(), GooglePermissionEntity.class);
         } else {

--- a/force-app/main/default/google-drive/classes/builders/GoogleDownloadFileBuilder.cls
+++ b/force-app/main/default/google-drive/classes/builders/GoogleDownloadFileBuilder.cls
@@ -1,0 +1,53 @@
+public class GoogleDownloadFileBuilder {
+    public enum DownloadType {METADATA, CONTENT}
+    private GoogleRequestBuilder requestGoogleBuilder;
+    private DownloadType selectedDownloadType;
+
+    public GoogleDownloadFileBuilder(GoogleDrive googleDriveInstance, String endpoint, String method) {
+        this.requestGoogleBuilder = new GoogleRequestBuilder(googleDriveInstance);
+        this.selectedDownloadType = DownloadType.METADATA; // By default, only metadata is retrieved
+
+        this.requestGoogleBuilder.setEndpoint(endpoint);
+        this.requestGoogleBuilder.setMethod(method);
+        this.requestGoogleBuilder.setHeader('User-Agent', googleDriveInstance.userAgentName);
+        this.requestGoogleBuilder.setHeader('Content-Type', 'application/json');
+    }
+
+    public GoogleDownloadFileBuilder setFileDownloadType(DownloadType downloadType) {
+        // The default behavior is to return only the metadata of the file, 
+        // with the parameter "alt=media" the returned type is the body of the file.
+        this.selectedDownloadType = downloadType;
+        if (downloadType == GoogleDownloadFileBuilder.DownloadType.CONTENT) {
+            this.requestGoogleBuilder.setParameter('alt', 'media');
+        } else if (downloadType == GoogleDownloadFileBuilder.DownloadType.METADATA) {
+            this.requestGoogleBuilder.removeParameter('alt');
+        }
+
+        return this;
+    }
+
+    public GoogleDownloadFileBuilder setSearchOnAllDrives(Boolean includeAllDrives) {
+        this.requestGoogleBuilder.setParameter('supportsAllDrives', includeAllDrives);
+        return this;
+    }
+
+    public GoogleFileEntity execute() {
+        HTTPResponse downloadResponse = this.requestGoogleBuilder.send();
+        return this.retrieveRequestDownloadWrapper(downloadResponse);
+    }
+
+    private GoogleFileEntity retrieveRequestDownloadWrapper(HTTPResponse downloadResponse) {
+        if (downloadResponse.getStatusCode() == GoogleConstants.HTTP_SUCCESS_STATUS_CODE) {
+            if (this.selectedDownloadType == GoogleDownloadFileBuilder.DownloadType.METADATA) {
+                return (GoogleFileEntity) JSON.deserialize(downloadResponse.getBody(), GoogleFileEntity.class);
+            } else {
+                GoogleFileEntity contentFileEntity = new GoogleFileEntity();
+                contentFileEntity.body = downloadResponse.getBody();
+                contentFileEntity.bodyAsBlob = downloadResponse.getBodyAsBlob();
+                return contentFileEntity;
+            }
+        } else {
+            throw new CalloutException(downloadResponse.getBody());
+        }
+    }
+}

--- a/force-app/main/default/google-drive/classes/builders/GoogleDownloadFileBuilder.cls-meta.xml
+++ b/force-app/main/default/google-drive/classes/builders/GoogleDownloadFileBuilder.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/google-drive/classes/builders/GoogleExportFileBuilder.cls
+++ b/force-app/main/default/google-drive/classes/builders/GoogleExportFileBuilder.cls
@@ -1,0 +1,33 @@
+public class GoogleExportFileBuilder {
+    private GoogleRequestBuilder requestGoogleBuilder;
+
+    public GoogleExportFileBuilder(GoogleDrive googleDriveInstance, String endpoint, String method) {
+        this.requestGoogleBuilder = new GoogleRequestBuilder(googleDriveInstance);
+
+        this.requestGoogleBuilder.setEndpoint(endpoint);
+        this.requestGoogleBuilder.setMethod(method);
+        this.requestGoogleBuilder.setHeader('User-Agent', googleDriveInstance.userAgentName);
+        this.requestGoogleBuilder.setHeader('Content-Type', 'application/json');
+    }
+
+    public GoogleExportFileBuilder setMimeType(String mimeType) {
+        this.requestGoogleBuilder.setParameter('mimeType', mimeType);
+        return this;
+    }
+
+    public GoogleFileEntity execute() {
+        HTTPResponse exportResponse = this.requestGoogleBuilder.send();
+        return this.retrieveRequestExportWrapper(exportResponse);
+    }
+
+    private GoogleFileEntity retrieveRequestExportWrapper(HTTPResponse exportResponse) {
+        if (exportResponse.getStatusCode() == GoogleConstants.HTTP_SUCCESS_STATUS_CODE) {
+            GoogleFileEntity contentFileEntity = new GoogleFileEntity();
+            contentFileEntity.body = exportResponse.getBody();
+            contentFileEntity.bodyAsBlob = exportResponse.getBodyAsBlob();
+            return contentFileEntity;
+        } else {
+            throw new CalloutException(exportResponse.getBody());
+        }
+    }
+}

--- a/force-app/main/default/google-drive/classes/builders/GoogleExportFileBuilder.cls-meta.xml
+++ b/force-app/main/default/google-drive/classes/builders/GoogleExportFileBuilder.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/google-drive/classes/builders/GoogleMultipartFileBuilder.cls
+++ b/force-app/main/default/google-drive/classes/builders/GoogleMultipartFileBuilder.cls
@@ -67,10 +67,10 @@ public class GoogleMultipartFileBuilder implements GoogleFileCreator {
         this.requestGoogleBuilder.setBody(this.buildMultipartRequestBody());
 
         HTTPResponse uploadResponse = this.requestGoogleBuilder.send();
-        return this.retrieveRequestUploadWrapper(uploadResponse);
+        return this.retrieveRequestCreateWrapper(uploadResponse);
     }
 
-    private GoogleFileEntity retrieveRequestUploadWrapper(HTTPResponse uploadResponse) {
+    private GoogleFileEntity retrieveRequestCreateWrapper(HTTPResponse uploadResponse) {
         if (uploadResponse.getStatusCode() == GoogleConstants.HTTP_SUCCESS_STATUS_CODE) {
             return (GoogleFileEntity) JSON.deserialize(uploadResponse.getBody(), GoogleFileEntity.class);
         } else {

--- a/force-app/main/default/google-drive/classes/builders/GoogleRequestBuilder.cls
+++ b/force-app/main/default/google-drive/classes/builders/GoogleRequestBuilder.cls
@@ -49,6 +49,11 @@ public class GoogleRequestBuilder {
         return this;
     }
 
+    public GoogleRequestBuilder removeParameter(String key) {
+        this.parameters.remove(key);
+        return this;
+    }
+
     public GoogleRequestBuilder setBody(String body) {
         this.bodyAsString = body;
         return this;

--- a/force-app/main/default/google-drive/classes/builders/GoogleSimpleFileBuilder.cls
+++ b/force-app/main/default/google-drive/classes/builders/GoogleSimpleFileBuilder.cls
@@ -36,10 +36,10 @@ public class GoogleSimpleFileBuilder implements GoogleFileCreator {
 
     public GoogleFileEntity execute() {
         HTTPResponse uploadResponse = this.requestGoogleBuilder.send();
-        return this.retrieveRequestUploadWrapper(uploadResponse);
+        return this.retrieveRequestCreateWrapper(uploadResponse);
     }
 
-    private GoogleFileEntity retrieveRequestUploadWrapper(HTTPResponse uploadResponse) {
+    private GoogleFileEntity retrieveRequestCreateWrapper(HTTPResponse uploadResponse) {
         if (uploadResponse.getStatusCode() == GoogleConstants.HTTP_SUCCESS_STATUS_CODE) {
             return (GoogleFileEntity) JSON.deserialize(uploadResponse.getBody(), GoogleFileEntity.class);
         } else {

--- a/force-app/main/default/google-drive/classes/entities/GoogleFileEntity.cls
+++ b/force-app/main/default/google-drive/classes/entities/GoogleFileEntity.cls
@@ -2,6 +2,8 @@ public class GoogleFileEntity {
     public String kind;
     public String driveId;
     public String fileExtension;
+    public String body;
+    public Blob bodyAsBlob;
     public Boolean copyRequiresWriterPermission;
     public String md5Checksum;
     public Boolean writersCanShare;

--- a/force-app/main/default/google-drive/classes/factories/GoogleRetrieveFileFactory.cls
+++ b/force-app/main/default/google-drive/classes/factories/GoogleRetrieveFileFactory.cls
@@ -1,0 +1,36 @@
+public class GoogleRetrieveFileFactory {
+    private GoogleDrive googleDriveInstance;
+
+    public GoogleRetrieveFileFactory(GoogleDrive googleDriveInstance) {
+        this.googleDriveInstance = googleDriveInstance;
+    }
+
+    /**
+     * Gets a file's metadata or content by ID.
+     * To download Google Docs, Sheets, and Slides use export() instead. 
+     * For more information, see https://developers.google.com/drive/api/guides/manage-downloads
+    */
+    public GoogleDownloadFileBuilder download(String fileId) {
+        return new GoogleDownloadFileBuilder(
+            this.googleDriveInstance,
+            this.buildRetrieveFileEndpoint(GoogleConstants.GET_FILE_ENDPOINT, fileId),
+            'GET'
+        );
+    }
+
+    /**
+     * Exports a Google Workspace document to the requested MIME type and returns a GoogleFileEntity record. 
+     * Note that the exported content is limited to 10MB.
+    */
+    public GoogleExportFileBuilder export(String fileId) {
+        return new GoogleExportFileBuilder(
+            this.googleDriveInstance,
+            this.buildRetrieveFileEndpoint(GoogleConstants.EXPORT_FILE_ENDPOINT, fileId),
+            'GET'
+        );
+    }
+
+    private String buildRetrieveFileEndpoint(String endpoint, String fileId) {
+        return String.format(endpoint, new List<String>{fileId});
+    }
+}

--- a/force-app/main/default/google-drive/classes/factories/GoogleRetrieveFileFactory.cls-meta.xml
+++ b/force-app/main/default/google-drive/classes/factories/GoogleRetrieveFileFactory.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
Implemented a factory and two builders for downloading (or exporting) files from Google Drive. Since files can generally be divided into two categories: files from Google Workspace (such as Google Docs, Google Sheets, etc.) and Other Files - different endpoints are used, and which one is determined by the factory.