### PR TITLE
FIX Version 1.1: Multipart Upload & Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ When you perform a simple upload, basic metadata is created and some attributes 
 In the example above, a simple upload is used to create a file in Google Drive. This type of upload does not support specifying metadata, so elements such as defining the file name, parent folder, etc., are not possible.
 
 #### Multipart Upload
-A multipart upload request lets you upload metadata and data in the same request. Use this option if the data you send is small enough to upload again, in its entirety, if the connection fails.
+A multipart upload request lets you upload metadata and data in the same request. Use this option if the data you send is small enough to upload again, in its entirety, if the connection fails. Please note that the library treats the document body as 'base64' encoded by default. If you're using a different encoding, you need to specify it explicitly, as shown below.
 
 ```java
   GoogleDrive testGoogleDrive = new GoogleDrive(testCredentials, userAgentName);
@@ -63,8 +63,16 @@ A multipart upload request lets you upload metadata and data in the same request
     .setFileName('Multipart Upload')
     .setMimeType('application/vnd.google-apps.document')
     .setParentFolders(new List<String>{'1TLCWgrczvSFnnJpU-6OEEEXMy77OVLjM', '1TLDWgrczvSFnnJpU-2OEEEXMy77OVLjM'})
-    .setBody('text/plain', 'base64', 'Hello World')
+    .setBody('text/plain', '8bit', 'Hello World')
     .execute();
+```
+
+If the document body is already in 'base64' encoding, there is a simplified version of the `setBody` method where only the content needs to be specified. In this case, the document type (the first parameter) will be determined automatically.
+
+```java
+  ...
+  .setBody(microsoftWordFileContent)
+  .execute();
 ```
 
 ### <span id="file-clone">Clone a file to Google Drive</span>

--- a/force-app/main/default/google-drive/classes/GoogleDriveTest.cls
+++ b/force-app/main/default/google-drive/classes/GoogleDriveTest.cls
@@ -110,6 +110,7 @@ private class GoogleDriveTest {
             .setMaxResult(3)
             .setSearchQuery('trashed = false')
             .setSearchOnAllDrives(true)
+            .setFields('fields/*')
             .setOrderBy('folder,modifiedTime desc,name')
             .execute();
         Assert.areEqual(3, result.files.size());
@@ -190,7 +191,7 @@ private class GoogleDriveTest {
             .setFileName('Multipart Upload')
             .setMimeType('application/vnd.google-apps.document')
             .setParentFolders(new List<String>{'1TLCWgrczvSFnnJpU-6OEEEXMy77OVLjM', '1TLDWgrczvSFnnJpU-2OEEEXMy77OVLjM'})
-            .setBody('text/plain', 'base64', 'Hello World')
+            .setBody('text/plain', '8bit', 'Hello World')
             .execute();
 
         // Fields that are specified in "setFields()" will be received 
@@ -222,7 +223,7 @@ private class GoogleDriveTest {
                 .setContentLength('11')
                 .setFields('id, name')
                 .setFileName('Multipart Failed Upload')
-                .setBody('Hello World')
+                .setBody('Hello World') // The standard "base64" encoding does not match the content
                 .execute();
         } catch (CalloutException ex) {
             Assert.areEqual(failedMultipartFileUpload, ex.getMessage());

--- a/force-app/main/default/google-drive/classes/builders/GoogleFileSearchBuilder.cls
+++ b/force-app/main/default/google-drive/classes/builders/GoogleFileSearchBuilder.cls
@@ -24,6 +24,11 @@ public class GoogleFileSearchBuilder {
         return this;
     }
 
+    public GoogleFileSearchBuilder setFields(String fields) {
+        this.requestGoogleBuilder.setParameter('fields', fields);
+        return this;
+    }
+
     public GoogleFileSearchBuilder setOrderBy(String orderBy) {
         this.requestGoogleBuilder.setParameter('orderBy', orderBy);
         return this;

--- a/force-app/main/default/google-drive/classes/builders/GoogleMultipartFileBuilder.cls
+++ b/force-app/main/default/google-drive/classes/builders/GoogleMultipartFileBuilder.cls
@@ -94,7 +94,7 @@ public class GoogleMultipartFileBuilder implements GoogleFileCreator {
             'Content-Type: application/json; charset=UTF-8\r\n\r\n' +
             '{1}\r\n' +
             '--{0}\r\n' +
-            'Content-Type: {2}\r\n\r\n' +
+            'Content-Type: {2}\r\n' +
             'Content-Transfer-Encoding: {3}\r\n\r\n' +
             '{4}\r\n' +
             '--{0}--',


### PR DESCRIPTION
An error in forming the body during the [multipart upload](https://developers.google.com/drive/api/guides/manage-uploads#multipart) was detected during regression testing, resulting in the file being uploaded incorrectly. See the details of the changes below:

- Changed the creation of the request body in the "GoogleMultipartFileBuilder" class, namely removed the extra "\r\n" that divided the body and uploaded the file incorrectly
- Added a new "setFields" method to the "GoogleMultipartFileBuilder" class, which now allows developer to set fields to return when searching for files.
- Changed the test class and READ.ME according to the changes.