### PR TITLE
#29, #24, #25: Resumable Upload (greater than 5 MB), Permission & File Removal

### DIFF
--- a/force-app/main/default/google-drive/GoogleConstants.cls
+++ b/force-app/main/default/google-drive/GoogleConstants.cls
@@ -3,13 +3,17 @@ public class GoogleConstants {
     public static final String SEARCH_FILES_ENDPOINT = 'https://www.googleapis.com/drive/v3/files';
     public static final String UPLOAD_FILES_ENDPOINT = 'https://www.googleapis.com/upload/drive/v3/files';
     public static final String CLONE_FILE_ENDPOINT = 'https://www.googleapis.com/drive/v3/files/{0}/copy';
+    public static final String DELETE_FILE_ENDPOINT = 'https://www.googleapis.com/drive/v3/files/{0}';
     public static final String NEW_PERMISSION_FILE_ENDPOINT = 'https://www.googleapis.com/drive/v3/files/{0}/permissions';
+    public static final String DELETE_PERMISSION_FILE_ENDPOINT = 'https://www.googleapis.com/drive/v3/files/{0}/permissions/{1}';
     public static final String EXPORT_FILE_ENDPOINT = 'https://www.googleapis.com/drive/v3/files/{0}/export';
     public static final String GET_FILE_ENDPOINT = 'https://www.googleapis.com/drive/v3/files/{0}';
 
-    public static final Integer HTTP_SUCCESS_STATUS_CODE = 200;
+    public static final List<Integer> HTTP_SUCCESS_STATUS_CODES = new List<Integer>{200, 201, 204, 206, 304, 308};
+    public static final List<Integer> HTTP_INTERRUPTED_STATUS_CODES = new List<Integer>{503, 308};
     public static final Integer HTTP_UNAUTHORIZED_STATUS_CODE = 401;
 
+    public static final Integer UPLOAD_DEFAULT_INITIAL_BYTE = 0;
     public static final Integer SEARCH_DEFAULT_PAGE_SIZE = 100;
 
     public static final String MULTIPART_DEFAULT_TYPE = 'related';

--- a/force-app/main/default/google-drive/classes/GoogleDrive.cls
+++ b/force-app/main/default/google-drive/classes/GoogleDrive.cls
@@ -73,6 +73,9 @@ public without sharing class GoogleDrive {
             return searchBuilder;
         }
 
+        /**
+         * Use this upload type to transfer a small media file (5 MB or less) without supplying metadata.
+        */
         public GoogleSimpleFileBuilder simpleCreate() {
             return new GoogleSimpleFileBuilder(
                 googleDriveInstance,
@@ -81,8 +84,24 @@ public without sharing class GoogleDrive {
             );
         }
 
+        /**
+         * Use this upload type to transfer a small file (5 MB or less) 
+         * along with metadata that describes the file, in a single request.
+        */
         public GoogleMultipartFileBuilder multipartCreate() {
             return new GoogleMultipartFileBuilder(
+                googleDriveInstance,
+                GoogleConstants.UPLOAD_FILES_ENDPOINT,
+                'POST'
+            );
+        }
+
+        /**
+         * Use this upload type for large files (greater than 5 MB) that include metadata and are uploaded in chunks.
+         * Each chunk must be represented as a split blob to be sent in the body of the HTTP request.
+         */
+         public GoogleResumableFileBuilder resumableCreate() {
+            return new GoogleResumableFileBuilder(
                 googleDriveInstance,
                 GoogleConstants.UPLOAD_FILES_ENDPOINT,
                 'POST'
@@ -99,6 +118,15 @@ public without sharing class GoogleDrive {
                 fileId,
                 GoogleConstants.CLONE_FILE_ENDPOINT,
                 'POST'
+            );
+        }
+
+        public GoogleDeleteFileBuilder remove(String fileId) {
+            return new GoogleDeleteFileBuilder(
+                googleDriveInstance,
+                fileId,
+                GoogleConstants.DELETE_FILE_ENDPOINT,
+                'DELETE'
             );
         }
 

--- a/force-app/main/default/google-drive/classes/GoogleDriveTest.cls
+++ b/force-app/main/default/google-drive/classes/GoogleDriveTest.cls
@@ -8,7 +8,7 @@ private class GoogleDriveTest {
         String fullDriveSearchBody = '{"kind":"drive#fileList","drives":[{"id":"drive123","name":"My Drive","colorRgb":"#FFFFFF","kind":"drive#drive","backgroundImageLink":"https://example.com/image.png","capabilities":{"canAddChildren":true,"canComment":true,"canCopy":true,"canDeleteDrive":false,"canDownload":true,"canEdit":true,"canListChildren":true,"canManageMembers":true,"canReadRevisions":true,"canRename":true,"canRenameDrive":true,"canChangeDriveBackground":true,"canShare":true,"canChangeCopyRequiresWriterPermissionRestriction":false,"canChangeDomainUsersOnlyRestriction":false,"canChangeDriveMembersOnlyRestriction":false,"canChangeSharingFoldersRequiresOrganizerPermissionRestriction":false,"canResetDriveRestrictions":false,"canDeleteChildren":false,"canTrashChildren":true},"themeId":"theme123","backgroundImageFile":{"id":"image123","xCoordinate":100.0,"yCoordinate":50.0,"width":800.0},"createdTime":"2023-06-15T10:30:00Z","hidden":false,"restrictions":{"copyRequiresWriterPermission":true,"domainUsersOnly":false,"driveMembersOnly":true,"adminManagedRestrictions":false,"sharingFoldersRequiresOrganizerPermission":true},"orgUnitId":"org123"},{"id":"drive456","name":"Not Populated Drive"}]}';
         GoogleDriveHttpMockGenerator testCalloutMock = new GoogleDriveHttpMockGenerator(
             GoogleConstants.SEARCH_DRIVES_ENDPOINT,
-            GoogleConstants.HTTP_SUCCESS_STATUS_CODE,
+            200,
             fullDriveSearchBody
         );
 
@@ -31,7 +31,7 @@ private class GoogleDriveTest {
         String nextPageDriveSearchBody = '{"nextPageToken": "2fd620046218c04c12709a67c4879de9","kind":"drive#fileList","drives":[{"id":"drive123","name":"My Drive","colorRgb":"#FFFFFF","kind":"drive#drive","backgroundImageLink":"https://example.com/image.png","capabilities":{"canAddChildren":true,"canComment":true,"canCopy":true,"canDeleteDrive":false,"canDownload":true,"canEdit":true,"canListChildren":true,"canManageMembers":true,"canReadRevisions":true,"canRename":true,"canRenameDrive":true,"canChangeDriveBackground":true,"canShare":true,"canChangeCopyRequiresWriterPermissionRestriction":false,"canChangeDomainUsersOnlyRestriction":false,"canChangeDriveMembersOnlyRestriction":false,"canChangeSharingFoldersRequiresOrganizerPermissionRestriction":false,"canResetDriveRestrictions":false,"canDeleteChildren":false,"canTrashChildren":true},"themeId":"theme123","backgroundImageFile":{"id":"image123","xCoordinate":100.0,"yCoordinate":50.0,"width":800.0},"createdTime":"2023-06-15T10:30:00Z","hidden":false,"restrictions":{"copyRequiresWriterPermission":true,"domainUsersOnly":false,"driveMembersOnly":true,"adminManagedRestrictions":false,"sharingFoldersRequiresOrganizerPermission":true},"orgUnitId":"org123"},{"id":"drive456","name":"Not Populated Drive"}]}';
         GoogleDriveHttpMockGenerator testCalloutMock = new GoogleDriveHttpMockGenerator(
             GoogleConstants.SEARCH_DRIVES_ENDPOINT,
-            GoogleConstants.HTTP_SUCCESS_STATUS_CODE,
+            200,
             nextPageDriveSearchBody
         );
 
@@ -75,7 +75,7 @@ private class GoogleDriveTest {
         String nextPageFileSearchBody = '{"nextPageToken": "~!!~AI9FV7ThOnDGgvVJDf_o4en1NZxTE_2tX-FVRhM-0UKO3MxOQh-dMLY4EiA==","kind": "drive#fileList","incompleteSearch": true,"files": [{"kind": "drive#file","mimeType": "application/vnd.google-apps.folder","id": "1dmEbuynf_W6064Acrx8RrpqU4EL60mRs","name": "Test"},{"kind": "drive#file","mimeType": "application/vnd.google-apps.folder","id": "1porUCOPDqUHXji8jCRqfG4cjj1gmJTVL","name": "audio"},{"kind": "drive#file","mimeType": "video/quicktime","id": "1ZqgilKNUpNIwvAotA5ss7Wc6swBmApkD","name": "Test.MOV"}]}';
         GoogleDriveHttpMockGenerator testCalloutMock = new GoogleDriveHttpMockGenerator(
             GoogleConstants.SEARCH_FILES_ENDPOINT,
-            GoogleConstants.HTTP_SUCCESS_STATUS_CODE,
+            200,
             nextPageFileSearchBody
         );
 
@@ -97,7 +97,7 @@ private class GoogleDriveTest {
         String fullFileSearchBody = '{"kind": "drive#fileList","incompleteSearch": false,"files": [{"kind": "drive#file","mimeType": "application/vnd.google-apps.folder","id": "1dmEbuynf_W6064Acrx8RrpqU4EL60mRs","name": "Test"},{"kind": "drive#file","mimeType": "application/vnd.google-apps.folder","id": "1porUCOPDqUHXji8jCRqfG4cjj1gmJTVL","name": "audio"},{"kind": "drive#file","mimeType": "video/quicktime","id": "1ZqgilKNUpNIwvAotA5ss7Wc6swBmApkD","name": "Test.MOV"}]}';
         GoogleDriveHttpMockGenerator testCalloutMock = new GoogleDriveHttpMockGenerator(
             GoogleConstants.SEARCH_FILES_ENDPOINT,
-            GoogleConstants.HTTP_SUCCESS_STATUS_CODE,
+            200,
             fullFileSearchBody
         );
 
@@ -145,7 +145,7 @@ private class GoogleDriveTest {
         String successSimpleFileUpload = '{"id": "1ZdR3cU-rXTxY3g8B9yJH9kR7A4kx0gk9","name": "My Document","driveId": "0BwwA4oUTeiV1UVNwOHItT0xfa0U","fileExtension": "docx","copyRequiresWriterPermission": false,"md5Checksum": "d41d8cd98f00b204e9800998ecf8427e","writersCanShare": true,"viewedByMe": true,"mimeType": "application/vnd.google-apps.document","exportLinks": {"application/pdf": "https://drive.google.com/uc?id=1ZdR3cU-rXTxY3g8B9yJH9kR7A4kx0gk9&export=pdf"},"parents": ["0BwwA4oUTeiV1NHRlWE56R2EwOEU"],"thumbnailLink": "https://drive.google.com/thumbnail?id=1ZdR3cU-rXTxY3g8B9yJH9kR7A4kx0gk9","iconLink": "https://drive.google.com/icon?id=1ZdR3cU-rXTxY3g8B9yJH9kR7A4kx0gk9","shared": false,"lastModifyingUser": {"displayName": "John Doe","kind": "drive#user","me": true,"permissionId": "123456789","emailAddress": "johndoe@example.com","photoLink": "https://example.com/photo.jpg"},"owners": [{"displayName": "John Doe","kind": "drive#user","me": true,"permissionId": "123456789","emailAddress": "johndoe@example.com","photoLink": "https://example.com/photo.jpg"}],"headRevisionId": "0123456789","sharingUser": {"displayName": "Jane Doe","kind": "drive#user","me": false,"permissionId": "987654321","emailAddress": "janedoe@example.com","photoLink": "https://example.com/photo2.jpg"},"webViewLink": "https://drive.google.com/file/d/1ZdR3cU-rXTxY3g8B9yJH9kR7A4kx0gk9/view","webContentLink": "https://drive.google.com/uc?id=1ZdR3cU-rXTxY3g8B9yJH9kR7A4kx0gk9&export=download","size": "102400","viewersCanCopyContent": true,"permissions": [{"id": "1234567890","displayName": "Jane Doe","type": "user","kind": "drive#permission","permissionDetails": [],"photoLink": "https://example.com/photo2.jpg","emailAddress": "janedoe@example.com","role": "reader","allowFileDiscovery": false,"domain": "","expirationTime": "","teamDrivePermissionDetails": [],"deleted": false,"view": "","pendingOwner": false}],"hasThumbnail": true,"spaces": ["drive"],"folderColorRgb": "#FF0000","description": "A sample document","starred": false,"trashed": false,"explicitlyTrashed": false,"createdTime": "2024-06-29T12:00:00.000Z","modifiedTime": "2024-06-29T12:30:00.000Z","modifiedByMeTime": "2024-06-29T12:15:00.000Z","viewedByMeTime": "2024-06-29T12:20:00.000Z","sharedWithMeTime": "2024-06-29T12:10:00.000Z","quotaBytesUsed": "102400","version": "1","originalFilename": "my_document.docx","ownedByMe": true,"fullFileExtension": "docx","properties": {"key1": "value1"},"appProperties": {"key2": "value2"},"isAppAuthorized": true,"teamDriveId": "0BwwA4oUTeiV1UVNwOHItT0xfa0U","capabilities": {"canEdit": true,"canComment": true,"canShare": true},"hasAugmentedPermissions": false,"trashingUser": {"displayName": "John Doe","kind": "drive#user","me": true,"permissionId": "123456789","emailAddress": "johndoe@example.com","photoLink": "https://example.com/photo.jpg"},"thumbnailVersion": "1","trashedTime": "","modifiedByMe": true,"permissionIds": ["1234567890"],"imageMediaMetadata": {"width": 800,"height": 600},"videoMediaMetadata": {"width": 1920,"height": 1080,"durationMillis": "120000"},"shortcutDetails": {"targetId": "0BwwA4oUTeiV1UVNwOHItT0xfa0U","targetMimeType": "application/vnd.google-apps.folder","targetResourceKey": "resourceKey123"},"resourceKey": "resourceKey123","linkShareMetadata": {"securityUpdateEligible": true,"securityUpdateEnabled": true},"sha1Checksum": "da39a3ee5e6b4b0d3255bfef95601890afd80709","sha256Checksum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}';
         GoogleDriveHttpMockGenerator testCalloutMock = new GoogleDriveHttpMockGenerator(
             GoogleConstants.UPLOAD_FILES_ENDPOINT,
-            GoogleConstants.HTTP_SUCCESS_STATUS_CODE,
+            200,
             successSimpleFileUpload
         );
 
@@ -158,7 +158,7 @@ private class GoogleDriveTest {
             .setContentType('text/plain')
             .setContentLength(11)
             .setFields('id, name, driveId, fileExtension, copyRequiresWriterPermission, md5Checksum, writersCanShare, viewedByMe, mimeType, exportLinks, parents, thumbnailLink, iconLink, shared, lastModifyingUser, owners, headRevisionId, sharingUser, webViewLink, webContentLink, size, viewersCanCopyContent, permissions, hasThumbnail, spaces, folderColorRgb, description, starred, trashed, explicitlyTrashed, createdTime, modifiedTime, modifiedByMeTime, viewedByMeTime, sharedWithMeTime, quotaBytesUsed, version, originalFilename, ownedByMe, fullFileExtension, properties, appProperties, isAppAuthorized, teamDriveId, capabilities, hasAugmentedPermissions, trashingUser, thumbnailVersion, trashedTime, modifiedByMe, permissionIds, imageMediaMetadata, videoMediaMetadata, shortcutDetails, resourceKey, linkShareMetadata, sha1Checksum, sha256Checksum')
-            .setContentBody('Hello World')
+            .setBody(Blob.valueOf('Hello World'))
             .execute();
 
         // Fields that are specified in "setFields()" will be received 
@@ -176,7 +176,7 @@ private class GoogleDriveTest {
         String successMultipartFileUpload = '{"id": "1ZdR3cU-rXTxY3g8B9yJH9kR7A4kx0gk9","name": "My Document","driveId": "0BwwA4oUTeiV1UVNwOHItT0xfa0U","fileExtension": "docx","copyRequiresWriterPermission": false,"md5Checksum": "d41d8cd98f00b204e9800998ecf8427e","writersCanShare": true,"viewedByMe": true,"mimeType": "application/vnd.google-apps.document","exportLinks": {"application/pdf": "https://drive.google.com/uc?id=1ZdR3cU-rXTxY3g8B9yJH9kR7A4kx0gk9&export=pdf"},"parents": ["0BwwA4oUTeiV1NHRlWE56R2EwOEU"],"thumbnailLink": "https://drive.google.com/thumbnail?id=1ZdR3cU-rXTxY3g8B9yJH9kR7A4kx0gk9","iconLink": "https://drive.google.com/icon?id=1ZdR3cU-rXTxY3g8B9yJH9kR7A4kx0gk9","shared": false,"lastModifyingUser": {"displayName": "John Doe","kind": "drive#user","me": true,"permissionId": "123456789","emailAddress": "johndoe@example.com","photoLink": "https://example.com/photo.jpg"},"owners": [{"displayName": "John Doe","kind": "drive#user","me": true,"permissionId": "123456789","emailAddress": "johndoe@example.com","photoLink": "https://example.com/photo.jpg"}],"headRevisionId": "0123456789","sharingUser": {"displayName": "Jane Doe","kind": "drive#user","me": false,"permissionId": "987654321","emailAddress": "janedoe@example.com","photoLink": "https://example.com/photo2.jpg"},"webViewLink": "https://drive.google.com/file/d/1ZdR3cU-rXTxY3g8B9yJH9kR7A4kx0gk9/view","webContentLink": "https://drive.google.com/uc?id=1ZdR3cU-rXTxY3g8B9yJH9kR7A4kx0gk9&export=download","size": "102400","viewersCanCopyContent": true,"permissions": [{"id": "1234567890","displayName": "Jane Doe","type": "user","kind": "drive#permission","permissionDetails": [],"photoLink": "https://example.com/photo2.jpg","emailAddress": "janedoe@example.com","role": "reader","allowFileDiscovery": false,"domain": "","expirationTime": "","teamDrivePermissionDetails": [],"deleted": false,"view": "","pendingOwner": false}],"hasThumbnail": true,"spaces": ["drive"],"folderColorRgb": "#FF0000","description": "A sample document","starred": false,"trashed": false,"explicitlyTrashed": false,"createdTime": "2024-06-29T12:00:00.000Z","modifiedTime": "2024-06-29T12:30:00.000Z","modifiedByMeTime": "2024-06-29T12:15:00.000Z","viewedByMeTime": "2024-06-29T12:20:00.000Z","sharedWithMeTime": "2024-06-29T12:10:00.000Z","quotaBytesUsed": "102400","version": "1","originalFilename": "my_document.docx","ownedByMe": true,"fullFileExtension": "docx","properties": {"key1": "value1"},"appProperties": {"key2": "value2"},"isAppAuthorized": true,"teamDriveId": "0BwwA4oUTeiV1UVNwOHItT0xfa0U","capabilities": {"canEdit": true,"canComment": true,"canShare": true},"hasAugmentedPermissions": false,"trashingUser": {"displayName": "John Doe","kind": "drive#user","me": true,"permissionId": "123456789","emailAddress": "johndoe@example.com","photoLink": "https://example.com/photo.jpg"},"thumbnailVersion": "1","trashedTime": "","modifiedByMe": true,"permissionIds": ["1234567890"],"imageMediaMetadata": {"width": 800,"height": 600},"videoMediaMetadata": {"width": 1920,"height": 1080,"durationMillis": "120000"},"shortcutDetails": {"targetId": "0BwwA4oUTeiV1UVNwOHItT0xfa0U","targetMimeType": "application/vnd.google-apps.folder","targetResourceKey": "resourceKey123"},"resourceKey": "resourceKey123","linkShareMetadata": {"securityUpdateEligible": true,"securityUpdateEnabled": true},"sha1Checksum": "da39a3ee5e6b4b0d3255bfef95601890afd80709","sha256Checksum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}';
         GoogleDriveHttpMockGenerator testCalloutMock = new GoogleDriveHttpMockGenerator(
             GoogleConstants.UPLOAD_FILES_ENDPOINT,
-            GoogleConstants.HTTP_SUCCESS_STATUS_CODE,
+            200,
             successMultipartFileUpload
         );
 
@@ -232,12 +232,67 @@ private class GoogleDriveTest {
     }
 
     @isTest
-    private static void testClone() {
+    private static void testResumableFileUpload() {
+        String successInitializedUri = 'https://www.googleapis.com/upload/drive/v3/files?uploadType=resumable&upload_id=ADPycjXkG3_J2JkRhql6g9lPqXEd75CMfbk1fP4O6ZWB7wNHUpl9Tp6V0kF9';
+        String successResumableFileUpload = '{"id": "1ZdR3cU-rXTxY3g8B9yJH9kR7A4kx0gk9"}';
+
+        Test.startTest();
+        buildGoogleDriveInfo();
+
+        GoogleDrive testGoogleDrive = new GoogleDrive(testCredentials, userAgentName);
+        
+        // Before uploading a file in parts, the transaction must be initialized, during which all metadata is specified
+        GoogleDriveHttpMockGenerator testInitCalloutMock = new GoogleDriveHttpMockGenerator(GoogleConstants.UPLOAD_FILES_ENDPOINT, 200, '', new Map<String, String>{'Location' => successInitializedUri});
+        Test.setMock(HttpCalloutMock.class, testInitCalloutMock);
+        GoogleBigFileEntity initResult = testGoogleDrive.files().resumableCreate()
+            .setFields('id')
+            .setFileName('Resumable Upload File')
+            .setMimeType('application/vnd.google-apps.document')
+            .setParentFolders(new List<String>{'1TLCWgrczvSFnnJpU-6OEEEXMy77OVLjM'})
+            .initialize();
+
+        // The initialization process results in an endpoint with Uniform Resource Identifier (URI)
+        Assert.areEqual(successInitializedUri, initResult.resumableSessionId);
+
+        // It is not necessary to have the complete document body (as the heap size is limited); having the total size in bytes is sufficient
+        Blob fullFileBody = Blob.valueOf('Hello World');
+
+        // Upload a portion of the document & specify the starting byte and the document's total size
+        Blob firstFileChunk = Blob.valueOf('Hello');
+        GoogleDriveHttpMockGenerator testChunkCalloutMock = new GoogleDriveHttpMockGenerator(initResult.resumableSessionId, 308, '', new Map<String, String>{'Range' => 'bytes=0-5'});
+        Test.setMock(HttpCalloutMock.class, testChunkCalloutMock);
+        GoogleBigFileEntity chunksResult = testGoogleDrive.files().resumableCreate()
+            .setExistingSessionUri(initResult.resumableSessionId)
+            .setBody(firstFileChunk)
+            .setStartByte(0)
+            .setTotalBytes(fullFileBody.size())
+            .execute();
+
+        // Uploading a chunk returns the number of bytes successfully uploaded, which may not always match the expected bytes
+        Assert.areNotEqual(0, chunksResult.resumableLatestByte);
+
+        // Upload the second part of the document by specifying a new body and starting byte
+        Blob secondFileChunk = Blob.valueOf(' World');
+        GoogleDriveHttpMockGenerator testUploadCalloutMock = new GoogleDriveHttpMockGenerator(initResult.resumableSessionId, 201, successResumableFileUpload);
+        Test.setMock(HttpCalloutMock.class, testUploadCalloutMock);
+        chunksResult = testGoogleDrive.files().resumableCreate()
+            .setExistingSessionUri(initResult.resumableSessionId)
+            .setBody(secondFileChunk)
+            .setStartByte(chunksResult.resumableLatestByte)
+            .setTotalBytes(fullFileBody.size())
+            .execute();
+
+        Assert.isNotNull(chunksResult.file);
+        Test.stopTest();
+    }
+
+    @isTest
+    private static void testCloneFile() {
         String testFileId = '1lhu72ZrlfzRljhP4t12RE5GDGa8n7Yv8LHWy20_QBqw';
         String successFileCloned = '{"kind": "drive#file","id": "1lhu72ZrlfzRljhP4t12RE5GDGa8n7Yv8LHWy20_QBqw","name": "CopiedDocument"}';
         GoogleDriveHttpMockGenerator testCalloutMock = new GoogleDriveHttpMockGenerator(
             buildFileDependentEndpoint(GoogleConstants.CLONE_FILE_ENDPOINT, testFileId),
-            GoogleConstants.HTTP_SUCCESS_STATUS_CODE,
+            200,
             successFileCloned
         );
 
@@ -261,12 +316,32 @@ private class GoogleDriveTest {
     }
 
     @isTest
+    private static void testDeleteFile() {
+        String testFileId = '1lhu72ZrlfzRljhP4t12RE5GDGa8n7Yv8LHWy20_QBqw';
+        GoogleDriveHttpMockGenerator testCalloutMock = new GoogleDriveHttpMockGenerator(
+            buildFileDependentEndpoint(GoogleConstants.DELETE_FILE_ENDPOINT, testFileId),
+            204,
+            ''
+        );
+
+        Test.startTest();
+        Test.setMock(HttpCalloutMock.class, testCalloutMock);
+        buildGoogleDriveInfo();
+
+        GoogleDrive testGoogleDrive = new GoogleDrive(testCredentials, userAgentName);
+        testGoogleDrive.files().remove(testFileId)
+            .setSupportsAllDrives(true)
+            .execute();
+        Test.stopTest();
+    }
+
+    @isTest
     private static void testPermissionFileCreate() {
         String testFileId = '1lhu72ZrlfzRljhP4t12RE5GDGa8n7Yv8LHWy20_QBqw';
         String successFilePermissionCreated = '{"kind": "drive#permission","id": "1lhu72ZrlfzRljhP4t12RE5GDGa8n7Yv8LHWy20_QBqw","type": "user","emailAddress": "test@gmail.com","role": "reader","domain": "","allowFileDiscovery": false,"displayName": "Example User"}';
         GoogleDriveHttpMockGenerator testCalloutMock = new GoogleDriveHttpMockGenerator(
             buildFileDependentEndpoint(GoogleConstants.NEW_PERMISSION_FILE_ENDPOINT, testFileId),
-            GoogleConstants.HTTP_SUCCESS_STATUS_CODE,
+            200,
             successFilePermissionCreated
         );
 
@@ -288,12 +363,35 @@ private class GoogleDriveTest {
     }
 
     @isTest
+    private static void testPermissionFileDelete() {
+        String testFileId = '1lhu72ZrlfzRljhP4t12RE5GDGa8n7Yv8LHWy20_QBqw';
+        String testPermissionId = '01649911713816498250';
+        GoogleDriveHttpMockGenerator testCalloutMock = new GoogleDriveHttpMockGenerator(
+            buildFileDependentEndpoint(GoogleConstants.NEW_PERMISSION_FILE_ENDPOINT, testFileId, testPermissionId),
+            204,
+            ''
+        );
+
+        Test.startTest();
+        Test.setMock(HttpCalloutMock.class, testCalloutMock);
+        buildGoogleDriveInfo();
+
+        GoogleDrive testGoogleDrive = new GoogleDrive(testCredentials, userAgentName);
+        testGoogleDrive.files().permission().remove(testFileId, testPermissionId)
+            .setDomainAdminAccess(true)
+            .setSupportsAllDrives(false)
+            .execute();
+
+        Test.stopTest();
+    }
+
+    @isTest
     private static void testRetrieveFileByDownloadMetadata() {
         String testFileId = '1lhu72ZrlfzRljhP4t12RE5GDGa8n7Yv8LHWy20_QBqw';
         String successFileDownloaded = '{"kind": "drive#file","id": "1lhu72ZrlfzRljhP4t12RE5GDGa8n7Yv8LHWy20_QBqw","name": "filename","mimeType": "application/pdf"}';
         GoogleDriveHttpMockGenerator testCalloutMock = new GoogleDriveHttpMockGenerator(
             buildFileDependentEndpoint(GoogleConstants.GET_FILE_ENDPOINT, testFileId),
-            GoogleConstants.HTTP_SUCCESS_STATUS_CODE,
+            200,
             successFileDownloaded
         );
 
@@ -317,7 +415,7 @@ private class GoogleDriveTest {
         String successFileDownloaded = 'JVBERi0xLjUKJdP0zOEKNSAwIG9iaiA8PAovQ3JlYXRvciAoQWRvYmUgUERGIGxpYn';
         GoogleDriveHttpMockGenerator testCalloutMock = new GoogleDriveHttpMockGenerator(
             buildFileDependentEndpoint(GoogleConstants.GET_FILE_ENDPOINT, testFileId),
-            GoogleConstants.HTTP_SUCCESS_STATUS_CODE,
+            200,
             successFileDownloaded
         );
 
@@ -340,7 +438,7 @@ private class GoogleDriveTest {
         String successFileExported = '{"body": {"content": [{"endIndex": 650, "paragraph": {"elements": [{"endIndex": 650, "startIndex": 590, "textRun": {"content": "And this is a paragraph that follows the level two heading.\n", "textStyle": {}}}], "paragraphStyle": {"direction": "LEFT_TO_RIGHT", "namedStyleType": "NORMAL_TEXT"}}, "startIndex": 590}]}, "documentId": "1lhu72ZrlfzRljhP4t12RE5GDGa8n7Yv8LHWy20_QBqw", "documentStyle": {}, "lists": {}, "namedStyles": {"styles": []}, "revisionId": "np_INheZiecEMA", "suggestionsViewMode": "SUGGESTIONS_INLINE", "title": "Test mule"}';
         GoogleDriveHttpMockGenerator testCalloutMock = new GoogleDriveHttpMockGenerator(
             buildFileDependentEndpoint(GoogleConstants.EXPORT_FILE_ENDPOINT, testFileId),
-            GoogleConstants.HTTP_SUCCESS_STATUS_CODE,
+            200,
             successFileExported
         );
 
@@ -359,6 +457,10 @@ private class GoogleDriveTest {
 
     private static String buildFileDependentEndpoint(String baseEndpoint, String fileId) {
         return String.format(baseEndpoint, new List<String>{fileId});
+    }
+
+    private static String buildFileDependentEndpoint(String baseEndpoint, String fileId, String whateverId) {
+        return String.format(baseEndpoint, new List<String>{fileId, whateverId});
     }
 
     private static void buildGoogleDriveInfo() {

--- a/force-app/main/default/google-drive/classes/builders/GoogleCloneFileBuilder.cls
+++ b/force-app/main/default/google-drive/classes/builders/GoogleCloneFileBuilder.cls
@@ -1,13 +1,10 @@
 public class GoogleCloneFileBuilder implements GoogleFileCreator {
     private GoogleRequestBuilder requestGoogleBuilder;
-
-    private String metadataFileName;
-    private String metadataMimeType;
-    private List<String> metadataParentFolders;
-
+    private GoogleFileMetadataBuilder fileMetadataBuilder;
+    
     public GoogleCloneFileBuilder(GoogleDrive googleDriveInstance, String fileId, String endpoint, String method) {
         this.requestGoogleBuilder = new GoogleRequestBuilder(googleDriveInstance);
-        this.metadataParentFolders = new List<String>();
+        this.fileMetadataBuilder = new GoogleFileMetadataBuilder();
 
         this.requestGoogleBuilder.setEndpoint(this.buildCloneFileEndpoint(endpoint, fileId));
         this.requestGoogleBuilder.setMethod(method);
@@ -21,22 +18,22 @@ public class GoogleCloneFileBuilder implements GoogleFileCreator {
     }
 
     public GoogleCloneFileBuilder setFileName(String fileName) {
-        this.metadataFileName = fileName;
+        this.fileMetadataBuilder.setFileProperty('name', fileName);
         return this;
     }
 
     public GoogleCloneFileBuilder setMimeType(String mimeType) {
-        this.metadataMimeType = mimeType;
+        this.fileMetadataBuilder.setFileProperty('mimeType', mimeType);
         return this;
     }
 
     public GoogleCloneFileBuilder setParentFolders(List<String> folderIds) {
-        this.metadataParentFolders = folderIds;
+        this.fileMetadataBuilder.setFileProperty('parents', folderIds);
         return this;
     }
 
     public GoogleFileEntity execute() {
-        String cloneBody = this.buildCloningRequestBody();
+        String cloneBody = this.fileMetadataBuilder.build();
         this.requestGoogleBuilder.setHeader('Content-Length', cloneBody.length());
         this.requestGoogleBuilder.setBody(cloneBody);
 
@@ -45,7 +42,7 @@ public class GoogleCloneFileBuilder implements GoogleFileCreator {
     }
 
     private GoogleFileEntity retrieveRequestClonedWrapper(HTTPResponse cloneResponse) {
-        if (cloneResponse.getStatusCode() == GoogleConstants.HTTP_SUCCESS_STATUS_CODE) {
+        if (GoogleConstants.HTTP_SUCCESS_STATUS_CODES.contains(cloneResponse.getStatusCode())) {
             return (GoogleFileEntity) JSON.deserialize(cloneResponse.getBody(), GoogleFileEntity.class);
         } else {
             throw new CalloutException(cloneResponse.getBody());
@@ -54,25 +51,5 @@ public class GoogleCloneFileBuilder implements GoogleFileCreator {
 
     private String buildCloneFileEndpoint(String baseEndpoint, String fileId) {
         return String.format(baseEndpoint, new List<String>{fileId});
-    }
-
-    private String buildCloningRequestBody() {
-        Map<String, Object> fileMetadata = new Map<String, Object>();
-        this.addPairIfNotEmpty(fileMetadata, 'name', this.metadataFileName);
-        this.addPairIfNotEmpty(fileMetadata, 'mimeType', this.metadataMimeType);
-        this.addPairIfNotEmpty(fileMetadata, 'parents', this.metadataParentFolders);
-        return fileMetadata.isEmpty() ? '' : JSON.serialize(fileMetadata, true);
-    }
-
-    private void addPairIfNotEmpty(Map<String, Object> originMap, String key, String value) {
-        if (String.isNotBlank(value)) {
-            originMap.put(key, value);
-        }
-    }
-
-    private void addPairIfNotEmpty(Map<String, Object> originMap, String key, List<String> values) {
-        if (values != null && !values.isEmpty()) {
-            originMap.put(key, values);
-        }
     }
 }

--- a/force-app/main/default/google-drive/classes/builders/GoogleCreatePermissionFileBuilder.cls
+++ b/force-app/main/default/google-drive/classes/builders/GoogleCreatePermissionFileBuilder.cls
@@ -47,7 +47,7 @@ public class GoogleCreatePermissionFileBuilder {
     }
 
     private GooglePermissionEntity retrieveRequestPermissionWrapper(HTTPResponse permissionResponse) {
-        if (permissionResponse.getStatusCode() == GoogleConstants.HTTP_SUCCESS_STATUS_CODE) {
+        if (GoogleConstants.HTTP_SUCCESS_STATUS_CODES.contains(permissionResponse.getStatusCode())) {
             return (GooglePermissionEntity) JSON.deserialize(permissionResponse.getBody(), GooglePermissionEntity.class);
         } else {
             throw new CalloutException(permissionResponse.getBody());

--- a/force-app/main/default/google-drive/classes/builders/GoogleDeleteFileBuilder.cls
+++ b/force-app/main/default/google-drive/classes/builders/GoogleDeleteFileBuilder.cls
@@ -1,0 +1,31 @@
+public class GoogleDeleteFileBuilder {
+    private GoogleRequestBuilder requestGoogleBuilder;
+
+    public GoogleDeleteFileBuilder(GoogleDrive googleDriveInstance, String fileId, String endpoint, String method) {
+        this.requestGoogleBuilder = new GoogleRequestBuilder(googleDriveInstance);
+
+        this.requestGoogleBuilder.setEndpoint(this.buildDeleteFileEndpoint(endpoint, fileId));
+        this.requestGoogleBuilder.setMethod(method);
+        this.requestGoogleBuilder.setHeader('User-Agent', googleDriveInstance.userAgentName);
+    }
+
+    public GoogleDeleteFileBuilder setSupportsAllDrives(Boolean includeAllDrives) {
+        this.requestGoogleBuilder.setParameter('supportsAllDrives', includeAllDrives);
+        return this;
+    }
+
+    public void execute() {
+        HTTPResponse deleteResponse = this.requestGoogleBuilder.send();
+        this.validateDeletionPermissionRequest(deleteResponse);
+    }
+
+    private void validateDeletionPermissionRequest(HTTPResponse deleteResponse) {
+        if (!GoogleConstants.HTTP_SUCCESS_STATUS_CODES.contains(deleteResponse.getStatusCode())) {
+            throw new CalloutException(deleteResponse.getBody());
+        }
+    }
+
+    private String buildDeleteFileEndpoint(String baseEndpoint, String fileId) {
+        return String.format(baseEndpoint, new List<String>{fileId});
+    }
+}

--- a/force-app/main/default/google-drive/classes/builders/GoogleDeleteFileBuilder.cls-meta.xml
+++ b/force-app/main/default/google-drive/classes/builders/GoogleDeleteFileBuilder.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/google-drive/classes/builders/GoogleDeletePermissionFileBuilder.cls
+++ b/force-app/main/default/google-drive/classes/builders/GoogleDeletePermissionFileBuilder.cls
@@ -1,0 +1,32 @@
+public class GoogleDeletePermissionFileBuilder {
+    private GoogleRequestBuilder requestGoogleBuilder;
+
+    public GoogleDeletePermissionFileBuilder(GoogleDrive googleDriveInstance, String endpoint, String method) {
+        this.requestGoogleBuilder = new GoogleRequestBuilder(googleDriveInstance);
+
+        this.requestGoogleBuilder.setEndpoint(endpoint);
+        this.requestGoogleBuilder.setMethod(method);
+        this.requestGoogleBuilder.setHeader('User-Agent', googleDriveInstance.userAgentName);
+    }
+
+    public GoogleDeletePermissionFileBuilder setSupportsAllDrives(Boolean includeAllDrives) {
+        this.requestGoogleBuilder.setParameter('supportsAllDrives', includeAllDrives);
+        return this;
+    }
+
+    public GoogleDeletePermissionFileBuilder setDomainAdminAccess(Boolean isDomainAdminAccess) {
+        this.requestGoogleBuilder.setParameter('useDomainAdminAccess', isDomainAdminAccess);
+        return this;
+    }
+
+    public void execute() {
+        HTTPResponse permissionResponse = this.requestGoogleBuilder.send();
+        this.validateDeletionPermissionRequest(permissionResponse);
+    }
+
+    private void validateDeletionPermissionRequest(HTTPResponse permissionResponse) {
+        if (!GoogleConstants.HTTP_SUCCESS_STATUS_CODES.contains(permissionResponse.getStatusCode())) {
+            throw new CalloutException(permissionResponse.getBody());
+        }
+    }
+}

--- a/force-app/main/default/google-drive/classes/builders/GoogleDeletePermissionFileBuilder.cls-meta.xml
+++ b/force-app/main/default/google-drive/classes/builders/GoogleDeletePermissionFileBuilder.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/google-drive/classes/builders/GoogleDownloadFileBuilder.cls
+++ b/force-app/main/default/google-drive/classes/builders/GoogleDownloadFileBuilder.cls
@@ -37,7 +37,7 @@ public class GoogleDownloadFileBuilder {
     }
 
     private GoogleFileEntity retrieveRequestDownloadWrapper(HTTPResponse downloadResponse) {
-        if (downloadResponse.getStatusCode() == GoogleConstants.HTTP_SUCCESS_STATUS_CODE) {
+        if (GoogleConstants.HTTP_SUCCESS_STATUS_CODES.contains(downloadResponse.getStatusCode())) {
             if (this.selectedDownloadType == GoogleDownloadFileBuilder.DownloadType.METADATA) {
                 return (GoogleFileEntity) JSON.deserialize(downloadResponse.getBody(), GoogleFileEntity.class);
             } else {

--- a/force-app/main/default/google-drive/classes/builders/GoogleDriveSearchBuilder.cls
+++ b/force-app/main/default/google-drive/classes/builders/GoogleDriveSearchBuilder.cls
@@ -35,7 +35,7 @@ public class GoogleDriveSearchBuilder {
     }
 
     private GoogleDriveSearchResult retrieveRequestSearchWrapper(HTTPResponse searchResponse) {
-        if (searchResponse.getStatusCode() == GoogleConstants.HTTP_SUCCESS_STATUS_CODE) {
+        if (GoogleConstants.HTTP_SUCCESS_STATUS_CODES.contains(searchResponse.getStatusCode())) {
             return (GoogleDriveSearchResult) JSON.deserialize(searchResponse.getBody(), GoogleDriveSearchResult.class);
         } else {
             throw new CalloutException(searchResponse.getBody());

--- a/force-app/main/default/google-drive/classes/builders/GoogleExportFileBuilder.cls
+++ b/force-app/main/default/google-drive/classes/builders/GoogleExportFileBuilder.cls
@@ -21,7 +21,7 @@ public class GoogleExportFileBuilder {
     }
 
     private GoogleFileEntity retrieveRequestExportWrapper(HTTPResponse exportResponse) {
-        if (exportResponse.getStatusCode() == GoogleConstants.HTTP_SUCCESS_STATUS_CODE) {
+        if (GoogleConstants.HTTP_SUCCESS_STATUS_CODES.contains(exportResponse.getStatusCode())) {
             GoogleFileEntity contentFileEntity = new GoogleFileEntity();
             contentFileEntity.body = exportResponse.getBody();
             contentFileEntity.bodyAsBlob = exportResponse.getBodyAsBlob();

--- a/force-app/main/default/google-drive/classes/builders/GoogleFileMetadataBuilder.cls
+++ b/force-app/main/default/google-drive/classes/builders/GoogleFileMetadataBuilder.cls
@@ -1,0 +1,31 @@
+public class GoogleFileMetadataBuilder {
+    private Map<String, Object> fileMetadata = new Map<String, Object>();
+
+    public GoogleFileMetadataBuilder setFileProperty(String filePropertyName, String filePropertyValue) {
+        this.addPairIfNotEmpty(filePropertyName, filePropertyValue);
+        return this;
+    }
+
+    public GoogleFileMetadataBuilder setFileProperty(String filePropertyName, List<String> filePropertyValues) {
+        this.addPairIfNotEmpty(filePropertyName, filePropertyValues);
+        return this;
+    }
+
+    public String build() {
+        return this.fileMetadata.isEmpty() 
+            ? '' 
+            : JSON.serialize(this.fileMetadata, true);
+    }
+
+    private void addPairIfNotEmpty(String key, String value) {
+        if (String.isNotBlank(value)) {
+            this.fileMetadata.put(key, value);
+        }
+    }
+
+    private void addPairIfNotEmpty(String key, List<String> values) {
+        if (values != null && !values.isEmpty()) {
+            this.fileMetadata.put(key, values);
+        }
+    }
+}

--- a/force-app/main/default/google-drive/classes/builders/GoogleFileMetadataBuilder.cls-meta.xml
+++ b/force-app/main/default/google-drive/classes/builders/GoogleFileMetadataBuilder.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/google-drive/classes/builders/GoogleFileSearchBuilder.cls
+++ b/force-app/main/default/google-drive/classes/builders/GoogleFileSearchBuilder.cls
@@ -51,7 +51,7 @@ public class GoogleFileSearchBuilder {
     }
 
     private GoogleFileSearchResult retrieveRequestSearchWrapper(HTTPResponse searchResponse) {
-        if (searchResponse.getStatusCode() == GoogleConstants.HTTP_SUCCESS_STATUS_CODE) {
+        if (GoogleConstants.HTTP_SUCCESS_STATUS_CODES.contains(searchResponse.getStatusCode())) {
             return (GoogleFileSearchResult) JSON.deserialize(searchResponse.getBody(), GoogleFileSearchResult.class);
         } else {
             throw new CalloutException(searchResponse.getBody());

--- a/force-app/main/default/google-drive/classes/builders/GoogleMultipartFileBuilder.cls
+++ b/force-app/main/default/google-drive/classes/builders/GoogleMultipartFileBuilder.cls
@@ -1,16 +1,14 @@
 public class GoogleMultipartFileBuilder implements GoogleFileCreator {
     private GoogleRequestBuilder requestGoogleBuilder;
+    private GoogleFileMetadataBuilder fileMetadataBuilder;
 
-    private String metadataFileName;
-    private String metadataMimeType;
-    private List<String> metadataParentFolders;
     private String dataContentType;
     private String dataTransferEncoding;
     private String dataContentBody;
 
     public GoogleMultipartFileBuilder(GoogleDrive googleDriveInstance, String endpoint, String method) {
         this.requestGoogleBuilder = new GoogleRequestBuilder(googleDriveInstance);
-        this.metadataParentFolders = new List<String>();
+        this.fileMetadataBuilder = new GoogleFileMetadataBuilder();
 
         this.requestGoogleBuilder.setEndpoint(endpoint);
         this.requestGoogleBuilder.setMethod(method);
@@ -35,17 +33,17 @@ public class GoogleMultipartFileBuilder implements GoogleFileCreator {
     }
 
     public GoogleMultipartFileBuilder setFileName(String fileName) {
-        this.metadataFileName = fileName;
+        this.fileMetadataBuilder.setFileProperty('name', fileName);
         return this;
     }
 
     public GoogleMultipartFileBuilder setMimeType(String mimeType) {
-        this.metadataMimeType = mimeType;
+        this.fileMetadataBuilder.setFileProperty('mimeType', mimeType);
         return this;
     }
 
     public GoogleMultipartFileBuilder setParentFolders(List<String> folderIds) {
-        this.metadataParentFolders = folderIds;
+        this.fileMetadataBuilder.setFileProperty('parents', folderIds);
         return this;
     }
 
@@ -71,7 +69,7 @@ public class GoogleMultipartFileBuilder implements GoogleFileCreator {
     }
 
     private GoogleFileEntity retrieveRequestCreateWrapper(HTTPResponse uploadResponse) {
-        if (uploadResponse.getStatusCode() == GoogleConstants.HTTP_SUCCESS_STATUS_CODE) {
+        if (GoogleConstants.HTTP_SUCCESS_STATUS_CODES.contains(uploadResponse.getStatusCode())) {
             return (GoogleFileEntity) JSON.deserialize(uploadResponse.getBody(), GoogleFileEntity.class);
         } else {
             throw new CalloutException(uploadResponse.getBody());
@@ -100,31 +98,11 @@ public class GoogleMultipartFileBuilder implements GoogleFileCreator {
             '--{0}--',
             new List<String>{
                 GoogleConstants.MULTIPART_REQUEST_BOUNDARY,
-                this.buildMultipartRequestMetadata(),
+                this.fileMetadataBuilder.build(),
                 this.dataContentType,
                 this.dataTransferEncoding,
                 this.dataContentBody
             }
         );
-    }
-
-    private String buildMultipartRequestMetadata() {
-        Map<String, Object> fileMetadata = new Map<String, Object>();
-        this.addPairIfNotEmpty(fileMetadata, 'name', this.metadataFileName);
-        this.addPairIfNotEmpty(fileMetadata, 'mimeType', this.metadataMimeType);
-        this.addPairIfNotEmpty(fileMetadata, 'parents', this.metadataParentFolders);
-        return fileMetadata.isEmpty() ? '' : JSON.serialize(fileMetadata, true);
-    }
-
-    private void addPairIfNotEmpty(Map<String, Object> originMap, String key, String value) {
-        if (String.isNotBlank(value)) {
-            originMap.put(key, value);
-        }
-    }
-
-    private void addPairIfNotEmpty(Map<String, Object> originMap, String key, List<String> values) {
-        if (values != null && !values.isEmpty()) {
-            originMap.put(key, values);
-        }
     }
 }

--- a/force-app/main/default/google-drive/classes/builders/GoogleRequestBuilder.cls
+++ b/force-app/main/default/google-drive/classes/builders/GoogleRequestBuilder.cls
@@ -14,6 +14,16 @@ public class GoogleRequestBuilder {
         this.parameters = new Map<String, String>();
     }
 
+    public GoogleRequestBuilder duplicate() {
+        GoogleRequestBuilder clonedGoogleRequest = this.clone();
+        clonedGoogleRequest.bodyAsString = null;
+        clonedGoogleRequest.bodyAsBlob = null;
+        clonedGoogleRequest.headers = new Map<String, String>();
+        clonedGoogleRequest.parameters = new Map<String, String>();
+
+        return clonedGoogleRequest;
+    }
+
     public GoogleRequestBuilder setEndpoint(String endpoint) {
         this.endpoint = endpoint;
         return this;

--- a/force-app/main/default/google-drive/classes/builders/GoogleResumableFileBuilder.cls
+++ b/force-app/main/default/google-drive/classes/builders/GoogleResumableFileBuilder.cls
@@ -1,0 +1,179 @@
+public with sharing class GoogleResumableFileBuilder {
+    private GoogleRequestBuilder requestGoogleBuilder;
+    private GoogleFileMetadataBuilder fileMetadataBuilder;
+
+    private Blob bodyChunk;
+    private String sessionUri;
+    private Long initialByte;
+    private Long totalBytes;
+
+    public GoogleResumableFileBuilder(GoogleDrive googleDriveInstance, String endpoint, String method) {
+        this.requestGoogleBuilder = new GoogleRequestBuilder(googleDriveInstance);
+        this.fileMetadataBuilder = new GoogleFileMetadataBuilder();
+
+        this.requestGoogleBuilder.setEndpoint(endpoint);
+        this.requestGoogleBuilder.setMethod(method);
+        this.requestGoogleBuilder.setHeader('User-Agent', googleDriveInstance.userAgentName);
+        this.requestGoogleBuilder.setHeader('Content-Type', 'application/json; charset=UTF-8');
+        this.requestGoogleBuilder.setParameter('uploadType', 'resumable');
+    }
+
+    public GoogleResumableFileBuilder setStartByte(Integer initialByte) {
+        this.initialByte = initialByte;
+        return this;
+    }
+
+    public GoogleResumableFileBuilder setStartByte(Long initialByte) {
+        this.initialByte = initialByte;
+        return this;
+    }
+
+    public GoogleResumableFileBuilder setTotalBytes(Integer totalBytes) {
+        this.totalBytes = totalBytes;
+        return this;
+    }
+
+    public GoogleResumableFileBuilder setTotalBytes(Long totalBytes) {
+        this.totalBytes = totalBytes;
+        return this;
+    }
+
+    public GoogleResumableFileBuilder setExistingSessionUri(String sessionUri) {
+        this.sessionUri = sessionUri;
+        return this;
+    }
+
+    public GoogleResumableFileBuilder setFields(String fields) {
+        this.requestGoogleBuilder.setParameter('fields', fields);
+        return this;
+    }
+
+    public GoogleResumableFileBuilder setFileName(String fileName) {
+        this.fileMetadataBuilder.setFileProperty('name', fileName);
+        return this;
+    }
+
+    public GoogleResumableFileBuilder setMimeType(String mimeType) {
+        this.fileMetadataBuilder.setFileProperty('mimeType', mimeType);
+        return this;
+    }
+
+    public GoogleResumableFileBuilder setParentFolders(List<String> folderIds) {
+        this.fileMetadataBuilder.setFileProperty('parents', folderIds);
+        return this;
+    }
+
+    public GoogleResumableFileBuilder setBody(Blob bodyPart) {
+        this.bodyChunk = bodyPart;
+        return this;
+    }
+
+    public GoogleResumableFileBuilder setBody(String bodyPart) {
+        this.bodyChunk = EncodingUtil.base64Decode(bodyPart);
+        return this;
+    }
+
+    public GoogleBigFileEntity initialize() {
+        this.requestGoogleBuilder.setBody(this.fileMetadataBuilder.build());
+        HTTPResponse uploadResponse = this.requestGoogleBuilder.send();
+        
+        GoogleBigFileEntity initialBigFile = this.retrieveRequestInitializeWrapper(uploadResponse);
+        this.sessionUri = initialBigFile.resumableSessionId;
+        return initialBigFile;
+    }
+
+    public GoogleBigFileEntity execute() {
+        this.assertValidState();
+
+        GoogleFileEntity uploadedFile = this.uploadFileChunk();
+        if (uploadedFile == null) {
+            GoogleBigFileEntity partiallyUploadedBigFile = new GoogleBigFileEntity();
+            partiallyUploadedBigFile.resumableSessionId = this.sessionUri;
+            partiallyUploadedBigFile.resumableLatestByte = this.initialByte;
+            return partiallyUploadedBigFile;
+        } else {
+            GoogleBigFileEntity fullyUploadedBigFile = new GoogleBigFileEntity();
+            fullyUploadedBigFile.file = uploadedFile;
+            return fullyUploadedBigFile;
+        }
+    }
+
+
+    private GoogleFileEntity uploadFileChunk() {
+        GoogleRequestBuilder partRequestGoogleBuilder = this.requestGoogleBuilder.duplicate();
+        partRequestGoogleBuilder.setEndpoint(this.sessionUri);
+        partRequestGoogleBuilder.setMethod('PUT');
+        partRequestGoogleBuilder.setHeader('Content-Length', this.bodyChunk.size());
+        partRequestGoogleBuilder.setHeader('Content-Range', this.buildPartContentRange(this.bodyChunk.size()));
+        partRequestGoogleBuilder.setBody(this.bodyChunk);
+
+        HTTPResponse chunkUploadResponse = partRequestGoogleBuilder.send();
+        if (GoogleConstants.HTTP_INTERRUPTED_STATUS_CODES.contains(chunkUploadResponse.getStatusCode())) {
+            String uploadedChunkRange = chunkUploadResponse.getHeader('Range');
+            this.calculateUploadedBytes(uploadedChunkRange);
+            return null;
+        } else {
+            return this.retrieveRequestCreateWrapper(chunkUploadResponse);
+        }
+    }
+
+    private GoogleBigFileEntity retrieveRequestInitializeWrapper(HTTPResponse uploadResponse) {
+        if (GoogleConstants.HTTP_SUCCESS_STATUS_CODES.contains(uploadResponse.getStatusCode())) {
+            GoogleBigFileEntity initializedBigFile = new GoogleBigFileEntity();
+            initializedBigFile.resumableSessionId = uploadResponse.getHeader('Location');
+            initializedBigFile.resumableLatestByte = GoogleConstants.UPLOAD_DEFAULT_INITIAL_BYTE;
+            return initializedBigFile;
+        } else {
+            throw new CalloutException(uploadResponse.getBody());
+        }
+    }
+
+    private GoogleFileEntity retrieveRequestCreateWrapper(HTTPResponse uploadResponse) {
+        if (GoogleConstants.HTTP_SUCCESS_STATUS_CODES.contains(uploadResponse.getStatusCode())) {
+            return (GoogleFileEntity) JSON.deserialize(uploadResponse.getBody(), GoogleFileEntity.class);
+        } else {
+            throw new CalloutException(uploadResponse.getBody());
+        }
+    }
+
+    private String buildPartContentRange(Long partSize) {
+        if (this.initialByte == null && this.totalBytes == null) {
+            return '*/*';
+        } else if (this.initialByte == null) {
+            return '*/' + this.totalBytes;
+        } else {
+            Long startByte = this.initialByte;
+            Long endByte = this.initialByte + partSize - 1;
+
+            String totalBytes = this.totalBytes != null ? String.valueOf(this.totalBytes) : '*';
+            return 'bytes ' + startByte + '-' + endByte + '/' + totalBytes;
+        }
+    }
+
+    private void calculateUploadedBytes(String uploadedRange) {
+        if (String.isNotBlank(uploadedRange)) {
+            String pattern = '\\d+$'; // Matches one or more digits at the end of the string
+            Pattern regex = System.Pattern.compile(pattern);
+            Matcher matcher = regex.matcher(uploadedRange);
+
+            String lastInteger = '';
+            if (matcher.find()) {
+                lastInteger = matcher.group(0);
+            }
+
+            this.initialByte = String.isNotBlank(lastInteger) ? Long.valueOf(lastInteger) : 0;
+        }
+    }
+
+    private void assertValidState() {
+        // Initialize the upload if no unique resource identifier is specified
+        if (String.isBlank(this.sessionUri)) {
+            this.initialize();
+        }
+        
+        // Fail fast: How can you upload a file chunk if there is no body for it?
+        if (this.bodyChunk == null || this.bodyChunk.size() == 0) {
+            throw new IllegalArgumentException('File chunk body is missing. Set the body using `setBody()` before sending');
+        }
+    }
+}

--- a/force-app/main/default/google-drive/classes/builders/GoogleResumableFileBuilder.cls-meta.xml
+++ b/force-app/main/default/google-drive/classes/builders/GoogleResumableFileBuilder.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/google-drive/classes/builders/GoogleSimpleFileBuilder.cls
+++ b/force-app/main/default/google-drive/classes/builders/GoogleSimpleFileBuilder.cls
@@ -19,12 +19,7 @@ public class GoogleSimpleFileBuilder implements GoogleFileCreator {
         return this;
     }
 
-    public GoogleSimpleFileBuilder setContentBody(String body) {
-        this.requestGoogleBuilder.setBody(body);
-        return this;
-    }
-
-    public GoogleSimpleFileBuilder setContentBody(Blob body) {
+    public GoogleSimpleFileBuilder setBody(Blob body) {
         this.requestGoogleBuilder.setBody(body);
         return this;
     }
@@ -40,7 +35,7 @@ public class GoogleSimpleFileBuilder implements GoogleFileCreator {
     }
 
     private GoogleFileEntity retrieveRequestCreateWrapper(HTTPResponse uploadResponse) {
-        if (uploadResponse.getStatusCode() == GoogleConstants.HTTP_SUCCESS_STATUS_CODE) {
+        if (GoogleConstants.HTTP_SUCCESS_STATUS_CODES.contains(uploadResponse.getStatusCode())) {
             return (GoogleFileEntity) JSON.deserialize(uploadResponse.getBody(), GoogleFileEntity.class);
         } else {
             throw new CalloutException(uploadResponse.getBody());

--- a/force-app/main/default/google-drive/classes/entities/GoogleBigFileEntity.cls
+++ b/force-app/main/default/google-drive/classes/entities/GoogleBigFileEntity.cls
@@ -1,0 +1,5 @@
+public class GoogleBigFileEntity {
+    @AuraEnabled public String resumableSessionId;
+    @AuraEnabled public Long resumableLatestByte;
+    public GoogleFileEntity file;
+}

--- a/force-app/main/default/google-drive/classes/entities/GoogleBigFileEntity.cls-meta.xml
+++ b/force-app/main/default/google-drive/classes/entities/GoogleBigFileEntity.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/google-drive/classes/entities/GoogleDriveSearchResult.cls
+++ b/force-app/main/default/google-drive/classes/entities/GoogleDriveSearchResult.cls
@@ -1,4 +1,4 @@
 public class GoogleDriveSearchResult {
-    public String nextPageToken;
+    @AuraEnabled public String nextPageToken;
     public List<GoogleDriveEntity> drives;
 }

--- a/force-app/main/default/google-drive/classes/entities/GoogleFileSearchResult.cls
+++ b/force-app/main/default/google-drive/classes/entities/GoogleFileSearchResult.cls
@@ -1,4 +1,4 @@
 public class GoogleFileSearchResult {
-    public String nextPageToken;
+    @AuraEnabled public String nextPageToken;
     public List<GoogleFileEntity> files;
 }

--- a/force-app/main/default/google-drive/classes/factories/GooglePermissionFileFactory.cls
+++ b/force-app/main/default/google-drive/classes/factories/GooglePermissionFileFactory.cls
@@ -13,7 +13,25 @@ public class GooglePermissionFileFactory {
         );
     }
 
+    public GoogleDeletePermissionFileBuilder remove(String fileId, String permissionId) {
+        return new GoogleDeletePermissionFileBuilder(
+            this.googleDriveInstance,
+            this.buildDeletePermissionFileEndpoint(fileId, permissionId),
+            'DELETE'
+        );
+    }
+
     private String buildCreatePermissionFileEndpoint(String fileId) {
         return String.format(GoogleConstants.NEW_PERMISSION_FILE_ENDPOINT, new List<String>{fileId});
+    }
+
+    private String buildDeletePermissionFileEndpoint(String fileId, String permissionId) {
+        return String.format(
+            GoogleConstants.DELETE_PERMISSION_FILE_ENDPOINT, 
+            new List<String>{
+                fileId,
+                permissionId
+            }
+        );
     }
 }

--- a/force-app/main/default/google-drive/interfaces/GoogleAuthorizer.cls
+++ b/force-app/main/default/google-drive/interfaces/GoogleAuthorizer.cls
@@ -6,9 +6,6 @@ public interface GoogleAuthorizer {
     /**
      * A method to be implemented outside of the library to obtain 
      * an access token for operating with the Google Drive API.
-     * 
-     * The implementation is not regulated, ensuring a secure approach 
-     * that avoids exposing actual access credentials.
     */
     String retrieveAccessToken();
 }

--- a/force-app/main/default/google-drive/interfaces/GoogleFileCreator.cls
+++ b/force-app/main/default/google-drive/interfaces/GoogleFileCreator.cls
@@ -1,6 +1,6 @@
 /** 
- * The GoogleFileCreator classifies builders that create files on Google Drive,
- * including those that work with files and have a return type of an instance of that file.
+ * GoogleFileCreator organizes builders focused on creating files in Google Drive. 
+ * This interface promotes uniformity and clarity across various builder implementations.
 */
 public interface GoogleFileCreator {
     GoogleFileEntity execute();


### PR DESCRIPTION
1. Implemented functionality for uploading a large file in parts using the resumable method (#29)
2. Implemented functionality for removing previously added permissions for a specific user on a Google Drive file/folder (#25)
3. Implemented functionality for deleting existing Google Drive files by their IDs (#24)

Full testing of functions was conducted due to changes in the structure caused by optimization and refactoring. The following test cases were covered:

1. File upload using Resumable and Multipart Upload - **PASS**
2. Creating and deleting permissions - **PASS**
3. Delete Google Drive file - **PASS**
4. Clone Google Drive file - **PASS**
5. File upload using Simple Upload - **PASS**
6. Google Drive Files Search - **PASS**
7. Google Drive Download File (Google Workspace & Not) - **PASS**

All added functionality was covered by tests, increasing the overall library coverage to **93.85%**